### PR TITLE
feat: tables folder config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,6 +1306,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "testdir",
+ "toml",
  "utf16string",
  "walkdir",
  "wild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ utf16string = "0.2.0"
 walkdir = "2.4.0"
 wild = "2.1.0"
 figment = { version = "0.10", features = ["toml", "env"] }
+toml = "0.7.8"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -207,13 +207,7 @@ fn write_config(config_file: &PathBuf, config: &Config) -> io::Result<()> {
 }
 
 pub fn default_tables_root(vpx_executable: &PathBuf) -> PathBuf {
-    // There might be a reason to keep the tables in another directory ? Disk space for example.
-    // Both Linux and MacOS is case sensitive, but Windows doesn't care. So we grab it from the executable name.
     vpx_executable.parent().unwrap().join("tables")
-}
-
-pub fn default_vpinball_executable(config: &Config) -> PathBuf {
-    PathBuf::from(config.vpx_executable.clone())
 }
 
 fn default_vpinball_executable_detection() -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,242 @@
+use std::path::{Path, PathBuf};
+
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::Select;
+use figment::{
+    providers::{Format, Toml},
+    Figment,
+};
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::{env, io};
+
+use std::io::Write;
+
+const CONFIGURATION_FILE_PATH: &str = "vpxtool.cfg";
+
+#[derive(Deserialize, Serialize)]
+pub struct Config {
+    pub vpx_executable: PathBuf,
+    pub tables_folder: Option<PathBuf>,
+}
+impl Config {
+    fn from(resolved_config: &ResolvedConfig) -> Self {
+        Config {
+            vpx_executable: resolved_config.vpx_executable.clone(),
+            tables_folder: Some(resolved_config.tables_folder.clone()),
+        }
+    }
+}
+
+pub struct ResolvedConfig {
+    pub vpx_executable: PathBuf,
+    pub tables_folder: PathBuf,
+}
+
+pub fn config_path() -> Option<PathBuf> {
+    let home_directory_configuration_path = home_config_path();
+    if home_directory_configuration_path.exists() {
+        return Some(home_directory_configuration_path);
+    } else {
+        let local_configuration_path = local_config_path();
+        if local_configuration_path.exists() {
+            return Some(local_configuration_path);
+        }
+    }
+    None
+}
+
+pub enum SetupConfigResult {
+    Configured(PathBuf),
+    Existing(PathBuf),
+}
+
+pub(crate) fn setup_config() -> io::Result<SetupConfigResult> {
+    // TODO check if the config file already exists
+    let existing_config_path = config_path();
+    match existing_config_path {
+        Some(path) => Ok(SetupConfigResult::Existing(path)),
+        None => {
+            // TODO avoid stdout interaction here
+            println!("Warning: Failed find a config file.");
+            let new_config = create_default_config()?;
+            Ok(SetupConfigResult::Configured(new_config.0))
+        }
+    }
+}
+
+pub fn load_or_setup_config() -> (PathBuf, ResolvedConfig) {
+    // Check if a configuration file can be found.
+    let existing_config_path = config_path();
+    let config_path = match existing_config_path {
+        Some(path) => path,
+        None => {
+            // TODO avoid stdout interaction here
+            println!("Warning: Failed find a config file.");
+            return create_default_config().unwrap();
+        }
+    };
+
+    // Just try to read both.
+    let figment = Figment::new().merge(Toml::file(&config_path));
+
+    // TODO avoid unwrap
+    let config: Config = figment.extract().unwrap();
+    let tables_folder = config
+        .tables_folder
+        .unwrap_or(default_tables_root(&config.vpx_executable));
+    let resolved_config = ResolvedConfig {
+        vpx_executable: config.vpx_executable,
+        tables_folder: tables_folder.clone(),
+    };
+    (config_path, resolved_config)
+}
+
+pub fn clear_config() -> io::Result<Option<PathBuf>> {
+    let config_path = config_path();
+    match config_path {
+        Some(path) => {
+            std::fs::remove_file(&path)?;
+            Ok(Some(path))
+        }
+        None => Ok(None),
+    }
+}
+
+fn local_config_path() -> PathBuf {
+    Path::new(CONFIGURATION_FILE_PATH).to_path_buf()
+}
+
+fn home_config_path() -> PathBuf {
+    dirs::config_dir().unwrap().join(CONFIGURATION_FILE_PATH)
+}
+
+fn create_default_config() -> io::Result<(PathBuf, ResolvedConfig)> {
+    let local_configuration_path = local_config_path();
+    let home_directory_configuration_path = home_config_path();
+
+    let choices: Vec<(&str, String)> = vec![
+        (
+            "Home",
+            home_directory_configuration_path
+                .to_string_lossy()
+                .to_string(),
+        ),
+        (
+            "Local",
+            local_configuration_path.to_string_lossy().to_string(),
+        ),
+    ];
+
+    let selection_opt = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Choose a configuration location:")
+        .default(0)
+        .items(
+            &choices
+                .iter()
+                .map(|(choice, description)| format!("{} \x1b[90m{}\x1b[0m", choice, description))
+                .collect::<Vec<_>>(),
+        )
+        .interact_opt()
+        .unwrap();
+
+    let config_file = if let Some(index) = selection_opt {
+        let (_selected_choice, path) = (&choices[index].0, &choices[index].1);
+        PathBuf::from(path)
+    } else {
+        unreachable!("Failed to select a configuration file path.");
+    };
+
+    let mut vpx_executable = default_vpinball_executable_detection();
+
+    if !vpx_executable.exists() {
+        println!("Warning: Failed to detect the vpinball executable.");
+        print!("vpinball executale path: ");
+        io::stdout().flush().expect("Failed to flush stdout");
+
+        let mut new_executable_path = String::new();
+        io::stdin()
+            .read_line(&mut new_executable_path)
+            .expect("Failed to read line");
+
+        vpx_executable = PathBuf::from(new_executable_path.trim().to_string());
+
+        if !vpx_executable.exists() {
+            println!("Error: input file path wasn't found.");
+            println!("Executable path is not set. ");
+
+            std::process::exit(1);
+        }
+    }
+
+    let tables_root = default_tables_root(&vpx_executable);
+
+    let resolved_config = ResolvedConfig {
+        vpx_executable: vpx_executable,
+        tables_folder: tables_root,
+    };
+    let config = Config::from(&resolved_config);
+
+    // write config to config_file
+    write_config(&config_file, &config)?;
+    Ok((config_file, resolved_config))
+}
+
+fn write_config(config_file: &PathBuf, config: &Config) -> io::Result<()> {
+    let toml = toml::to_string(&config).unwrap();
+    let mut file = File::create(config_file)?;
+    file.write_all(toml.as_bytes())?;
+    Ok(())
+}
+
+pub fn default_tables_root(vpx_executable: &PathBuf) -> PathBuf {
+    // There might be a reason to keep the tables in another directory ? Disk space for example.
+    // Both Linux and MacOS is case sensitive, but Windows doesn't care. So we grab it from the executable name.
+    vpx_executable.parent().unwrap().join("tables")
+}
+
+pub fn default_vpinball_executable(config: &Config) -> PathBuf {
+    PathBuf::from(config.vpx_executable.clone())
+}
+
+fn default_vpinball_executable_detection() -> PathBuf {
+    // TODO: Improve the executable detection.
+    let mut local = env::current_dir().unwrap();
+
+    if cfg!(target_os = "windows") {
+        // baller installer default
+        let dir = PathBuf::from("c:\\vPinball\\VisualPinball");
+        let exe = dir.join("VPinballX64.exe");
+
+        // Check current directory
+        if local.join("VPinballX64.exe").exists() {
+            local.join("VPinballX64.exe")
+        } else if local.join("VPinballX.exe").exists() {
+            local.join("VPinballX.exe")
+        } else if exe.exists() {
+            exe
+        } else {
+            dir.join("VPinballX.exe")
+        }
+    } else {
+        local = local.join("VPinballX_GL");
+
+        if local.exists() {
+            local
+        } else {
+            let home = dirs::home_dir().unwrap();
+            home.join("vpinball").join("vpinball").join("VPinballX_GL")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // test that we can read a incomplete config file with missing tables_folder
+    #[test]
+    fn test_read_incomplete_config() {
+        todo!("implement test")
+    }
+}

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -71,10 +71,10 @@ impl TableOption {
 }
 
 pub fn frontend_index(
-    tables_path: String,
+    tables_path: PathBuf,
     recursive: bool,
 ) -> Vec<(PathBuf, tableinfo::TableInfo)> {
-    println!("Indexing {}", tables_path);
+    println!("Indexing {}", &tables_path.display());
     let vpx_files = indexer::find_vpx_files(recursive, &tables_path).unwrap();
     let pb = ProgressBar::new(vpx_files.len() as u64);
     pb.set_style(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod directb2s;
 mod frontend;
 mod indexer;
@@ -7,7 +8,6 @@ pub mod vpx;
 use clap::{arg, Arg, Command};
 use colored::Colorize;
 use console::Emoji;
-use indicatif::style::ProgressTracker;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs::{metadata, File};
 use std::io::{self, Read};
@@ -20,6 +20,7 @@ use git_version::git_version;
 
 use base64::{engine::general_purpose, Engine as _};
 
+use crate::config::SetupConfigResult;
 use directb2s::load;
 use vpx::tableinfo::{self};
 use vpx::{cat_script, expanded, importvbs, verify, VerifyResult};
@@ -30,184 +31,13 @@ use crate::vpx::version;
 // see https://github.com/fusion-engineering/rust-git-version/issues/21
 const GIT_VERSION: &str = git_version!(args = ["--tags", "--always", "--dirty=-modified"]);
 
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::Select;
-use figment::{
-    providers::{Format, Toml},
-    Figment,
-};
-use serde::Deserialize;
-use std::env;
-const CONFIGURATION_FILE_PATH: &str = "vpxtool.cfg";
-
-#[derive(Deserialize)]
-struct Config {
-    vpx_executable: String,
-}
-
 const OK: Emoji = Emoji("✅", "[launch]");
 const NOK: Emoji = Emoji("❌", "[crash]");
 
-fn default_vpinball_executable_detection() -> PathBuf {
-    // TODO: Improve the executable detection.
-    let mut local = env::current_dir().unwrap();
-
-    if cfg!(target_os = "windows") {
-        // baller installer default
-        let dir = PathBuf::from("c:\\vPinball\\VisualPinball");
-        let exe = dir.join("VPinballX64.exe");
-
-        // Check current directory
-        if local.join("VPinballX64.exe").exists() {
-            local.join("VPinballX64.exe")
-        } else if local.join("VPinballX.exe").exists() {
-            local.join("VPinballX.exe")
-        } else if exe.exists() {
-            exe
-        } else {
-            dir.join("VPinballX.exe")
-        }
-    } else {
-        local = local.join("VPinballX_GL");
-
-        if local.exists() {
-            local
-        } else {
-            let home = dirs::home_dir().unwrap();
-            home.join("vpinball").join("vpinball").join("VPinballX_GL")
-        }
-    }
-}
-
-fn create_default_config() {
-    println!("Warning: Failed find a config file.");
-
-    let mut config_file = CONFIGURATION_FILE_PATH;
-
-    let home_directory_configuration_path =
-        dirs::config_dir().unwrap().join(CONFIGURATION_FILE_PATH);
-
-    let choices: Vec<(String, String)> = vec![
-        (
-            "Home".to_string(),
-            home_directory_configuration_path
-                .to_string_lossy()
-                .to_string(),
-        ),
-        ("Local".to_string(), format!("{}", CONFIGURATION_FILE_PATH)),
-    ];
-
-    let selection_opt = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Configuration location: ")
-        .default(0)
-        .items(
-            &choices
-                .iter()
-                .map(|(choice, description)| format!("{} \x1b[90m{}\x1b[0m", choice, description))
-                .collect::<Vec<_>>(),
-        )
-        .interact_opt()
-        .unwrap();
-
-    if let Some(index) = selection_opt {
-        let (_selected_choice, path) = (&choices[index].0, &choices[index].1);
-
-        config_file = path;
-    }
-
-    let mut vpx_executable = default_vpinball_executable_detection();
-
-    if !vpx_executable.exists() {
-        println!("Warning: Failed to detect the vpinball executable.");
-        print!("vpinball executale path: ");
-        io::stdout().flush().expect("Failed to flush stdout");
-
-        let mut new_executable_path = String::new();
-        io::stdin()
-            .read_line(&mut new_executable_path)
-            .expect("Failed to read line");
-
-        vpx_executable = PathBuf::from(new_executable_path.trim().to_string());
-
-        if !vpx_executable.exists() {
-            println!("Error: input file path wasn't found.");
-            println!("Executable path is not set. ");
-
-            std::process::exit(1);
-        }
-    }
-
-    let full_path = format!(
-        "vpx_executable = \"{}\"\n",
-        vpx_executable.to_string_lossy().to_string()
-    );
-
-    let file_result = File::create(config_file);
-    match file_result {
-        Ok(mut file) => {
-            let write_result = file.write_all(full_path.as_bytes());
-            match write_result {
-                Ok(_) => {
-                    println!("Configuration saved at {}.", config_file);
-                }
-                Err(err) => {
-                    eprintln!("Write error: {}", err);
-                }
-            }
-        }
-        Err(err) => {
-            eprintln!("File creation error: {}", err);
-        }
-    }
-}
-
-fn load_config() -> Config {
-    // Check if a configuration file can be found.
-    if !(dirs::config_dir()
-        .unwrap()
-        .join(CONFIGURATION_FILE_PATH)
-        .exists()
-        || Path::new(CONFIGURATION_FILE_PATH).exists())
-    {
-        create_default_config();
-    }
-
-    // Just try to read both.
-    let figment = Figment::new()
-        .merge(Toml::file(
-            dirs::config_dir().unwrap().join(CONFIGURATION_FILE_PATH),
-        ))
-        .merge(Toml::file(CONFIGURATION_FILE_PATH));
-
-    figment.extract().unwrap()
-}
-
-fn default_vpinball_executable() -> PathBuf {
-    let config = load_config();
-
-    PathBuf::from(config.vpx_executable)
-}
-
-fn default_tables_root() -> PathBuf {
-    let config = load_config();
-
-    // There might be a reason to keep the tables in another directory ? Disk space for example.
-    // Both Linux and MacOS is case sensitive, but Windows doesn't care. So we grab it from the executable name.
-    let parent_directory = Path::new(&config.vpx_executable)
-        .parent()
-        .unwrap()
-        .join("tables");
-
-    parent_directory
-}
-
 fn main() {
-    load_config();
-
     // to allow for non static strings in clap
     // I had to enable the "string" module
     // is this considered a bad idea?
-    let default_tables_root = default_tables_root().into_os_string();
     let matches = Command::new("vpxtool")
         .version(GIT_VERSION)
         .author("Francis DB")
@@ -242,9 +72,8 @@ fn main() {
                         .default_value("true"),
                 )
                 .arg(
-                    arg!(<VPXROOTPATH> "The path to the root directory of vpx files")
+                    arg!(<VPXROOTPATH> "The path to the root directory of vpx files. Defaults to what is set up in the config file.")
                         .required(false)
-                        .default_value(&default_tables_root)
                 ),
         )
         .subcommand(
@@ -259,9 +88,8 @@ fn main() {
                         .default_value("true"),
                 )
                 .arg(
-                    arg!(<VPXPATH> "The path(s) to the vpx file(s)")
+                    arg!(<VPXROOTPATH> "The path to the root directory of vpx files. Defaults to what is set up in the config file.")
                         .required(false)
-                        .default_value(&default_tables_root)
                 ),
         )
         .subcommand(
@@ -341,6 +169,30 @@ fn main() {
                 .about("Creates a minimal empty new vpx file")
                 .arg(arg!(<VPXPATH> "The path(s) to the vpx file").required(true)),
         )
+        .subcommand(
+            Command::new("config")
+                .subcommand_required(true)
+                .about("Vpxtool related config file")
+                .subcommand(
+                    Command::new("setup")
+                        .about("Sets up the config file"),
+                )
+                .subcommand(
+                    Command::new("path")
+                        .about("Shows the current config file path"),
+            ).subcommand(
+                Command::new("clear")
+                    .about("Clears the current config file"),
+                )
+            .subcommand(
+        Command::new("cat")
+            .about("Shows the contents of the config file"),
+            )
+                .subcommand(
+                    Command::new("edit")
+                        .about("Edits the config file using the default editor"),
+                )
+    )
         .get_matches_from(wild::args());
 
     match matches.subcommand() {
@@ -368,15 +220,11 @@ fn main() {
             }
         }
         Some(("frontend", sub_matches)) => {
-            let recursive = sub_matches.get_flag("RECURSIVE");
-            let path = sub_matches
-                .get_one::<String>("VPXROOTPATH")
-                .map(|s| s.as_str());
-            let tables_path = path.unwrap_or("");
-            let expanded_tables_path = expand_path(tables_path);
-            let vpx_files_with_tableinfo =
-                frontend::frontend_index(expanded_tables_path, recursive);
-            let vpinball_executable = default_vpinball_executable();
+            let (config_path, config) = config::load_or_setup_config();
+            let vpx_files_with_tableinfo = frontend::frontend_index(config.tables_folder, true);
+
+            println!("Using config file {}", config_path.display());
+            let vpinball_executable = config.vpx_executable;
             frontend::frontend(vpx_files_with_tableinfo, &vpinball_executable);
         }
         Some(("index", sub_matches)) => {
@@ -513,6 +361,71 @@ fn main() {
             println!("creating new vpx file at {}", expanded_path);
             new(expanded_path.as_ref()).unwrap();
         }
+        Some(("config", sub_matches)) => match sub_matches.subcommand() {
+            Some(("setup", _)) => match config::setup_config() {
+                Ok(SetupConfigResult::Configured(config_path)) => {
+                    println!("Created config file {}", config_path.display());
+                }
+                Ok(SetupConfigResult::Existing(config_path)) => {
+                    println!("Config file already exists at {}", config_path.display());
+                }
+                Err(e) => {
+                    eprintln!("Failed to create config file: {}", e);
+                    exit(1);
+                }
+            },
+            Some(("path", _)) => match config::config_path() {
+                Some(config_path) => {
+                    println!("{}", config_path.display());
+                }
+                None => {
+                    eprintln!("No config file found");
+                    exit(1);
+                }
+            },
+            Some(("cat", _)) => match config::config_path() {
+                Some(config_path) => {
+                    let mut file = File::open(&config_path).unwrap();
+                    let mut text = String::new();
+                    file.read_to_string(&mut text).unwrap();
+                    println!("{}", text);
+                }
+                None => {
+                    eprintln!("No config file found");
+                    exit(1);
+                }
+            },
+            Some(("clear", _)) => match config::clear_config() {
+                Ok(Some(config_path)) => {
+                    println!("Cleared config file {}", config_path.display());
+                }
+                Ok(None) => {
+                    println!("No config file found");
+                }
+                Err(e) => {
+                    eprintln!("Failed to clear config file: {}", e);
+                    exit(1);
+                }
+            },
+            Some(("edit", _)) => match config::config_path() {
+                Some(config_path) => {
+                    let editor = std::env::var("EDITOR").expect("EDITOR not set");
+                    let status = std::process::Command::new(editor)
+                        .arg(config_path)
+                        .status()
+                        .unwrap();
+                    if !status.success() {
+                        eprintln!("Failed to edit config file");
+                        exit(1);
+                    }
+                }
+                None => {
+                    eprintln!("No config file found");
+                    exit(1);
+                }
+            },
+            _ => unreachable!(),
+        },
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachable!()
     }
 }


### PR DESCRIPTION
Adds a config for tables folder
Refactors the whole config setup
Only the frontend will ask to set up a config
Commands added related to config

```
Usage: vpxtool config <COMMAND>

Commands:
  setup  Sets up the config file
  path   Shows the current config file path
  clear  Clears the current config file
  cat    Shows the contents of the config file
  edit   Edits the config file using the default editor
  help   Print this message or the help of the given subcommand(s)

```