### PR TITLE
fix: DTArray with alpha suffix

### DIFF
--- a/src/patcher.rs
+++ b/src/patcher.rs
@@ -86,7 +86,8 @@ fn patch_drop_target_array(script: String) -> String {
     // becomes
     // Set DT7 = (new DropTarget)(dt1, dt1a, pdt1, 7, 0, false)
     // Set DT27 = (new DropTarget)(dt2, dt2a, pdt2, 27, 0, false)
-    let re = Regex::new(r"(DT[a-zA-Z]*\d+\s*=\s*)Array\((.*?)\s*(,\s*(false|true))?\)").unwrap();
+    let re = Regex::new(r"(DT[a-zA-Z]*\d+[a-zA-Z]*\s*=\s*)Array\((.*?)\s*(,\s*(false|true))?\)")
+        .unwrap();
     let mut patched_script = re
         .replace_all(&script, |caps: &regex::Captures| {
             let ind = caps.get(1).unwrap().as_str();
@@ -222,10 +223,11 @@ End Class
     fn test_vbs_patch() {
         let script = r#"
 'Define a variable for each drop target
-Dim DT9, DT47
+Dim DT9, DT47, DTA1v
 
 DTBk9=Array(sw9, sw9a, sw9p, 9, 0, false)
 DT47 = Array(sw47, sw47a, sw47p, 47, 0)
+DTA1v = Array(DTA1, DTA1a, DTA1p, 1, 0)
 
 Sub DoDTAnim()
 	Dim i
@@ -285,10 +287,11 @@ Class DropTarget
 End Class
 
 'Define a variable for each drop target
-Dim DT9, DT47
+Dim DT9, DT47, DTA1v
 
 Set DTBk9=(new DropTarget)(sw9, sw9a, sw9p, 9, 0, false)
 Set DT47 = (new DropTarget)(sw47, sw47a, sw47p, 47, 0, false)
+Set DTA1v = (new DropTarget)(DTA1, DTA1a, DTA1p, 1, 0, false)
 
 Sub DoDTAnim()
 	Dim i


### PR DESCRIPTION
https://vpuniverse.com/files/file/9696-strip-joker-poker-gottlieb-1978-special-edition-complete-package/

Used to miss these lines

```vbscript
DTA1v = Array(DTA1, DTA1a, DTA1p, 1, 0)
DTA2v = Array(DTA2, DTA2a, DTA2p, 2, 0)
```