### PR TITLE
build: Also make release for aarch64-linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,14 @@ jobs:
             bin: vpxtool
             name: vpxtool-Linux-x86_64-musl.tar.gz
             cargo_command: cargo
-
+            
+          - os_name: Linux-aarch64
+            os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+            bin: vpxtool
+            name: vpxtool-Linux-aarch64-musl.tar.gz
+            cargo_command: cargo
+            
           - os_name: Windows-aarch64
             os: windows-latest
             target: aarch64-pc-windows-msvc


### PR DESCRIPTION
For example for Asahi Linux on mac

From reading the docs I think it's possible to build for multiple architectures at once but not doing that for now.
https://doc.rust-lang.org/cargo/commands/cargo-build.html#compilation-options