### PR TITLE
ci: pin to macOS-13

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - os: ubuntu-latest
           - os: windows-latest
-          - os: macOS-14
+          - os: macOS-13
 
     runs-on: ${{ matrix.platform.os }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - os: ubuntu-latest
           - os: windows-latest
-          - os: macOS-latest
+          - os: macOS-14
 
     runs-on: ${{ matrix.platform.os }}
 


### PR DESCRIPTION
`macOS-latest` defaults to `macOS-14-arm` that has cargo missing

see https://github.com/actions/runner-images/issues/9732