### PR TITLE
feat: assemble output file arg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             Some((CMD_INFO_SHOW, sub_matches)) => {
                 let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
                 let path = path.unwrap_or("");
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 println!("showing info for {}", expanded_path.display())?;
                 let info = info_gather(&expanded_path)?;
                 println!("{}", info)?;
@@ -117,21 +117,21 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             Some((CMD_INFO_EXTRACT, sub_matches)) => {
                 let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
                 let path = path.unwrap_or("");
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 println!("extracting info for {}", expanded_path.display())?;
                 info_extract(&expanded_path)
             }
             Some((CMD_INFO_IMPORT, sub_matches)) => {
                 let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
                 let path = path.unwrap_or("");
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 println!("importing info for {}", expanded_path.display())?;
                 info_import(&expanded_path)
             }
             Some((CMD_INFO_EDIT, sub_matches)) => {
                 let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
                 let path = path.unwrap_or("");
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let loaded_config = config::load_config()?;
                 let config = loaded_config.as_ref().map(|c| &c.1);
                 println!("editing info for {}", expanded_path.display())?;
@@ -141,7 +141,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             Some((CMD_INFO_DIFF, sub_matches)) => {
                 let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
                 let path = path.unwrap_or("");
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 println!("diffing info for {}", expanded_path.display())?;
                 let diff = info_diff(&expanded_path)?;
                 println!("{}", diff)?;
@@ -153,7 +153,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             // TODO this should diff more than only the script
             let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
             let path = path.unwrap_or("");
-            let expanded_path = expand_path(path)?;
+            let expanded_path = expand_path_exists(path)?;
             match script_diff(expanded_path) {
                 Ok(output) => {
                     println!("{}", output)?;
@@ -276,7 +276,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
 
             let (tables_folder_path, tables_index_path) = match path {
                 Some(path) => {
-                    let tables_path = expand_path(path)?;
+                    let tables_path = expand_path_exists(path)?;
                     let tables_index_path = config::tables_index_path(&tables_path);
                     (tables_path, tables_index_path)
                 }
@@ -322,7 +322,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|s| s.as_str())
                     .unwrap_or_default();
 
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let mut vpx_file = vpx::open(expanded_path)?;
                 let game_data = vpx_file.read_gamedata()?;
                 let code = game_data.code.string;
@@ -336,7 +336,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|s| s.as_str())
                     .unwrap_or_default();
 
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 match extractvbs(&expanded_path, false, None) {
                     Ok(ExtractResult::Existed(vbs_path)) => {
                         let warning =
@@ -361,7 +361,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|s| s.as_str())
                     .unwrap_or_default();
 
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 match importvbs(&expanded_path, None) {
                     Ok(vbs_path) => {
                         println!("IMPORTED {}", vbs_path.display())?;
@@ -380,7 +380,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|s| s.as_str())
                     .unwrap_or_default();
 
-                let expanded_vpx_path = expand_path(path)?;
+                let expanded_vpx_path = expand_path_exists(path)?;
 
                 let loaded_config = config::load_config()?;
                 let config = loaded_config.as_ref().map(|c| &c.1);
@@ -398,7 +398,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|s| s.as_str())
                     .unwrap_or_default();
 
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let diff = script_diff(expanded_path)?;
                 println!("{}", diff)?;
                 Ok(ExitCode::SUCCESS)
@@ -409,7 +409,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|s| s.as_str())
                     .unwrap_or_default();
 
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let vbs_path = match extractvbs(&expanded_path, false, None) {
                     Ok(ExtractResult::Existed(vbs_path)) => {
                         let warning =
@@ -442,7 +442,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .map(|s| s.as_str())
                 .unwrap_or_default();
 
-            let expanded_path = expand_path(path)?;
+            let expanded_path = expand_path_exists(path)?;
             ls(expanded_path.as_ref())?;
             Ok(ExitCode::SUCCESS)
         }
@@ -454,7 +454,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .map(|v| v.as_str())
                 .collect();
             paths.iter().try_for_each(|path| {
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let ext = expanded_path.extension().map(|e| e.to_ascii_lowercase());
                 match ext {
                     Some(ext) if ext == "directb2s" => {
@@ -480,8 +480,23 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .get_one::<String>("DIRPATH")
                 .map(|s| s.as_str())
                 .unwrap_or_default();
-            let expanded_dir_path = expand_path(dir_path)?;
-            let vpx_path = expanded_dir_path.with_extension("vpx");
+            let vpx_path_arg = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
+            let expanded_dir_path = expand_path_exists(dir_path)?;
+            let vpx_path = match vpx_path_arg {
+                Some(path) => expand_path(path),
+                None => {
+                    let file_name = match expanded_dir_path.file_name() {
+                        Some(name) => format!("{}.vpx", name.to_string_lossy()),
+                        None => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidInput,
+                                "Invalid directory path",
+                            ))
+                        }
+                    };
+                    expanded_dir_path.with_file_name(file_name)
+                }
+            };
             if vpx_path.exists() {
                 let confirmed = confirm(
                     format!("\"{}\" already exists.", vpx_path.display()),
@@ -516,7 +531,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .map(|v| v.as_str())
                 .collect::<Vec<_>>();
             for path in paths {
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 match extractvbs(&expanded_path, overwrite, None) {
                     Ok(ExtractResult::Existed(vbs_path)) => {
                         let warning =
@@ -536,7 +551,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
         }
         Some((CMD_IMPORT_VBS, sub_matches)) => {
             let path: &str = sub_matches.get_one::<String>("VPXPATH").unwrap().as_str();
-            let expanded_path = expand_path(path)?;
+            let expanded_path = expand_path_exists(path)?;
             match importvbs(&expanded_path, None) {
                 Ok(vbs_path) => {
                     println!("IMPORTED {}", vbs_path.display())?;
@@ -557,7 +572,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .map(|v| v.as_str())
                 .collect::<Vec<_>>();
             for path in paths {
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 match verify(&expanded_path) {
                     VerifyResult::Ok(vbs_path) => {
                         println!("{OK} {}", vbs_path.display())?;
@@ -654,7 +669,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .get_one::<String>("VPXPATH")
                     .map(|s| s.as_str())
                     .unwrap_or_default();
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let mut vpx_file = vpx::open_rw(&expanded_path)?;
                 let images = vpx_file.images_to_webp()?;
                 if !images.is_empty() {
@@ -679,7 +694,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .get_one::<String>("VPXPATH")
                     .map(|s| s.as_str())
                     .unwrap_or_default();
-                let expanded_path = expand_path(path)?;
+                let expanded_path = expand_path_exists(path)?;
                 let mut vpx_file = vpx::open(expanded_path)?;
                 let game_data = vpx_file.read_gamedata()?;
                 let json = game_data_to_json(&game_data);
@@ -909,7 +924,8 @@ fn build_command() -> Command {
         .subcommand(
             Command::new(CMD_ASSEMBLE)
                 .about("Assembles a vpx file")
-                .arg(arg!(<DIRPATH> "The path to the vpx structure").required(true)),
+                .arg(arg!(<DIRPATH> "The path to the extracted vpx structure").required(true))
+                .arg(arg!([VPXPATH] "Optional path of the VPX file to assemble to. Defaults to <DIRPATH>.vpx.")),
         )
         .subcommand(
             Command::new("new")
@@ -1142,7 +1158,11 @@ fn os_independent_file_name(file_path: String) -> Option<String> {
     file_path.rsplit(['/', '\\']).next().map(|f| f.to_string())
 }
 
-fn expand_path(path: &str) -> io::Result<PathBuf> {
+fn expand_path(path: &str) -> PathBuf {
+    shellexpand::tilde(path).to_string().into()
+}
+
+fn expand_path_exists(path: &str) -> io::Result<PathBuf> {
     // TODO expand all instead of only tilde?
     let expanded_path = shellexpand::tilde(path);
     match metadata(expanded_path.as_ref()) {
@@ -1387,7 +1407,7 @@ pub fn extract(vpx_file_path: &Path, yes: bool) -> io::Result<ExitCode> {
 }
 
 pub fn info_diff<P: AsRef<Path>>(vpx_file_path: P) -> io::Result<String> {
-    let expanded_vpx_path = expand_path(vpx_file_path.as_ref().to_str().unwrap())?;
+    let expanded_vpx_path = expand_path_exists(vpx_file_path.as_ref().to_str().unwrap())?;
     let info_file_path = expanded_vpx_path.with_extension("info.json");
     let original_info_path = vpx_file_path.as_ref().with_extension("info.original.tmp");
     if info_file_path.exists() {


### PR DESCRIPTION
```
> vpxtool help assemble`
Assembles a vpx file

Usage: vpxtool assemble [OPTIONS] <DIRPATH> [VPXPATH]

Arguments:
  <DIRPATH>  The path to the extracted vpx structure
  [VPXPATH]  Optional path of the VPX file to assemble to. Defaults to <DIRPATH>.vpx.

Options:
  -f, --force  Do not ask for confirmation before overwriting existing files
  -h, --help   Print help
```

Example below

```
vpxtool extract ~/tables/foo.vpx
vpxtool assemble ~/tables/foo ./foo.vpx
```

Also fixes the default file name bug.
fixes #382