### PR TITLE
Fix typo in launch_templates doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ Sometimes you want to use a different executables, extra arguments or environmen
 by setting up launch templates. Each entry will show up on top of the frontend table menu.
 
 ```toml
-[[launch_template]]
+[[launch_templates]]
 name = "Launch fullscreen"
 executable = "/home/myuser/vpinball/VPinballX_BGFX"
-args = ["-EnableTrueFullscreen"]
+arguments = ["-EnableTrueFullscreen"]
 
-[[launch_template]]
+[[launch_templates]]
 name = "Launch GL"
 executable = "/home/myuser/vpinball/VPinballX_GL"
-[launch_template.env]
+[launch_templates.env]
 SDL_VIDEODRIVER = "X11"
 ```
 


### PR DESCRIPTION
Fixes a typo in `launch_templates` documentation section of the README.

Great feature btw ! It popped out just when I needed it :+1: 