### PR TITLE
Add diff to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ vpxtool config edit
 
 ### Configuring vpinball paths
 
-```yaml
+```toml
 vpx_executable = "/home/myuser/vpinball/VPinballX_BGFX"
 
-  # Optional settings below, only needed if the defaults don't work
+# Optional settings below, only needed if the defaults don't work
 tables_folder = "/home/myuser/vpinball/tables"
 vpx_config = "/home/myuser/.vpinball/VPinballX.ini"
 ```
@@ -166,12 +166,22 @@ executable = "/home/myuser/vpinball/VPinballX_GL"
 SDL_VIDEODRIVER = "X11"
 ```
 
+### Configuring a custom diff
+
+When actions are invoked that run diff, the default diff configured for your system will be used. In case you
+want to override this with a specific diff, optionally specifying the path, you can add the following line to the config file:
+
+```toml
+# use mydiff as default diff
+diff = "/path/to/mydiff"
+```
+
 ### Configuring a custom editor
 
 When actions are invoked that open an editor, the default editor configured for your system will be used. In case you
-want to override this with a specific editor, you can add the following line to the config file:
+want to override this with a specific editor, optionally specifying the path, you can add the following line to the config file:
 
-```yaml
+```toml
 # use Visual Studio Code as default editor
 editor = "code"
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -193,8 +193,10 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
                 let path = path.unwrap_or("");
                 let expanded_path = expand_path_exists(path)?;
+                let loaded_config = config::load_config()?;
+                let config = loaded_config.as_ref().map(|c| &c.1);
                 crate::println!("diffing info for {}", expanded_path.display())?;
-                let diff = info_diff(&expanded_path)?;
+                let diff = info_diff(&expanded_path, config)?;
                 crate::println!("{}", diff)?;
                 Ok(ExitCode::SUCCESS)
             }
@@ -205,7 +207,9 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
             let path = path.unwrap_or("");
             let expanded_path = expand_path_exists(path)?;
-            match script_diff(&expanded_path) {
+            let loaded_config = config::load_config()?;
+            let config = loaded_config.as_ref().map(|c| &c.1);
+            match script_diff(&expanded_path, config) {
                 Ok(output) => {
                     crate::println!("{}", output)?;
                     Ok(ExitCode::SUCCESS)
@@ -325,7 +329,9 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .unwrap_or_default();
 
                 let expanded_path = expand_path_exists(path)?;
-                let diff = script_diff(&expanded_path)?;
+                let loaded_config = config::load_config()?;
+                let config = loaded_config.as_ref().map(|c| &c.1);
+                let diff = script_diff(&expanded_path, config)?;
                 crate::println!("{}", diff)?;
                 Ok(ExitCode::SUCCESS)
             }
@@ -1516,7 +1522,7 @@ pub fn extract(vpx_file_path: &Path, yes: bool) -> io::Result<ExitCode> {
     }
 }
 
-pub fn info_diff(vpx_file_path: &Path) -> io::Result<String> {
+pub fn info_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io::Result<String> {
     let expanded_vpx_path = expand_path_exists(vpx_file_path.to_str().unwrap())?;
     let info_file_path = expanded_vpx_path.with_extension("info.json");
     if info_file_path.exists() {
@@ -1528,7 +1534,12 @@ pub fn info_diff(vpx_file_path: &Path) -> io::Result<String> {
         } else {
             DiffColor::Never
         };
-        let output = run_diff(original_info_path.path(), &info_file_path, diff_color)?;
+        let output = run_diff(
+            original_info_path.path(),
+            &info_file_path,
+            diff_color,
+            config,
+        )?;
         Ok(String::from_utf8_lossy(&output).to_string())
     } else {
         let msg = format!("No sidecar info file found: {}", info_file_path.display());
@@ -1536,7 +1547,7 @@ pub fn info_diff(vpx_file_path: &Path) -> io::Result<String> {
     }
 }
 
-pub fn script_diff(vpx_file_path: &Path) -> io::Result<String> {
+pub fn script_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io::Result<String> {
     // set extension for PathBuf
     let vbs_path = vpx_file_path.with_extension("vbs");
     if vbs_path.exists() {
@@ -1552,7 +1563,7 @@ pub fn script_diff(vpx_file_path: &Path) -> io::Result<String> {
                 } else {
                     DiffColor::Never
                 };
-                let output = run_diff(original_vbs_path.path(), &vbs_path, diff_color)?;
+                let output = run_diff(original_vbs_path.path(), &vbs_path, diff_color, config)?;
                 Ok(String::from_utf8_lossy(&output).to_string())
             }
             Err(e) => {
@@ -1586,13 +1597,17 @@ pub fn run_diff(
     original_vbs_path: &Path,
     vbs_path: &Path,
     color: DiffColor,
+    config: Option<&ResolvedConfig>,
 ) -> Result<Vec<u8>, io::Error> {
     let original_vbs_filename = original_vbs_path
         .file_name()
         .unwrap_or(original_vbs_path.as_os_str());
     let original_vbs_file_name_no_tmp = original_vbs_filename.to_string_lossy().replace(".tmp", "");
     let vbs_filename = vbs_path.file_name().unwrap_or(vbs_path.as_os_str());
-    let mut command = std::process::Command::new("diff");
+    let diff = config
+        .and_then(|resolved| resolved.diff.as_deref())
+        .unwrap_or("diff");
+    let mut command = std::process::Command::new(diff);
     match vbs_path.parent() {
         Some(parent) if !parent.as_os_str().is_empty() => {
             command.current_dir(parent);
@@ -1610,7 +1625,7 @@ pub fn run_diff(
     info!("Running command: {:?}", &command);
     let result = command.output().map(|o| o.stdout);
     result.map_err(|e| {
-        let msg = format!("Failed to run 'diff'. Is it installed on your system? {e}");
+        let msg = format!("Failed to run diff '{diff}'. Is it installed on your system? {e}");
         io::Error::other(msg)
     })
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
     pub vpx_executable: PathBuf,
     pub vpx_config: Option<PathBuf>,
     pub tables_folder: Option<PathBuf>,
+    pub diff: Option<String>,
     pub editor: Option<String>,
     pub launch_templates: Option<Vec<LaunchTemplate>>,
 }
@@ -39,6 +40,7 @@ pub struct ResolvedConfig {
     pub vpx_config: PathBuf,
     pub tables_folder: PathBuf,
     pub tables_index_path: PathBuf,
+    pub diff: Option<String>,
     pub editor: Option<String>,
 }
 
@@ -166,6 +168,7 @@ fn read_config(config_path: &Path) -> io::Result<ResolvedConfig> {
         vpx_config,
         tables_folder: tables_folder.clone(),
         tables_index_path: tables_index_path(&tables_folder),
+        diff: config.diff,
         editor: config.editor,
     };
     Ok(resolved_config)
@@ -322,6 +325,7 @@ fn write_default_config(config_file: &Path, vpx_executable: &Path) -> io::Result
         launch_templates: Some(launch_templates),
         vpx_config: Some(vpx_config.clone()),
         tables_folder: Some(tables_folder.clone()),
+        diff: None,
         editor: None,
     };
     write_config(config_file, &config)?;
@@ -437,6 +441,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/home/me/tables"),
                 tables_index_path: PathBuf::from("/home/me/tables/vpxtool_index.json"),
+                diff: None,
                 editor: None,
             }
         );
@@ -484,6 +489,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/tmp/test/tables"),
                 tables_index_path: PathBuf::from("/tmp/test/tables/vpxtool_index.json"),
+                diff: None,
                 editor: None,
             }
         );
@@ -531,6 +537,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: expected_tables_dir.clone(),
                 tables_index_path: expected_tables_dir.join("vpxtool_index.json"),
+                diff: None,
                 editor: None,
             }
         );
@@ -554,6 +561,7 @@ mod tests {
                 vpx_config: PathBuf::from("C:\\test\\VPinballX.ini"),
                 tables_folder: PathBuf::from("C:\\test\\tables"),
                 tables_index_path: PathBuf::from("C:\\test\\tables\\vpxtool_index.json"),
+                diff: None,
                 editor: None,
                 launch_templates: vec!(
                     LaunchTemplate {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -282,7 +282,7 @@ fn table_menu(
                     prompt(&msg.truecolor(255, 125, 0).to_string());
                 }
             },
-            Some(TableOption::ShowVBSDiff) => match script_diff(selected_path) {
+            Some(TableOption::ShowVBSDiff) => match script_diff(selected_path, Some(config)) {
                 Ok(diff) => {
                     prompt(&diff);
                 }
@@ -362,7 +362,7 @@ fn table_menu(
                 let vbs_path = vbs_path_for(selected_path);
                 let patch_path = vbs_path.with_extension("vbs.patch");
 
-                match run_diff(&original_path, &vbs_path, DiffColor::Never) {
+                match run_diff(&original_path, &vbs_path, DiffColor::Never, Some(config)) {
                     Ok(diff) => {
                         let mut file = File::create(patch_path).unwrap();
                         file.write_all(&diff).unwrap();
@@ -391,7 +391,7 @@ fn table_menu(
                     prompt_error(&msg);
                 }
             },
-            Some(TableOption::InfoDiff) => match info_diff(selected_path) {
+            Some(TableOption::InfoDiff) => match info_diff(selected_path, Some(config)) {
                 Ok(diff) => {
                     prompt(&diff);
                 }


### PR DESCRIPTION
Fixes #697.

Successfully tested with the following config:
```toml
vpx_executable = 'D:\vpinballx\VPinballX_BGFX64.exe'
vpx_config = 'C:\Users\Sean\AppData\Roaming\VPinballX\10.8\VPinballX.ini'
tables_folder = '\\nas.local\Emulators\Pinball\Tables'
diff = 'C:\Users\Sean\scoop\apps\git\current\usr\bin\diff.exe'

[[launch_templates]]
name = "Launch"
executable = 'D:\vpinballx\VPinballX_BGFX64.exe'

[launch_templates.env]
SDL_VIDEODRIVER = ""
SDL_RENDER_DRIVER = ""

[[launch_templates]]
name = "Launch Fullscreen"
executable = 'D:\vpinballx\VPinballX_BGFX64.exe'
arguments = ["-EnableTrueFullscreen"]

[[launch_templates]]
name = "Launch Windowed"
executable = 'D:\vpinballx\VPinballX_BGFX64.exe'
arguments = ["-DisableTrueFullscreen"]
```