### PR TITLE
Performance & Index Improvements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,6 +86,7 @@ const CMD_ROMNAME: &str = "romname";
 
 const CMD_INDEX: &str = "index";
 const ARG_VERBOSE: &str = "VERBOSE";
+const ARG_MAX_DEPTH: &str = "MAX_DEPTH";
 
 pub(crate) struct ProgressBarProgress {
     pb: ProgressBar,
@@ -220,12 +221,16 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 }
             }
         }
-        Some((CMD_FRONTEND, _sub_matches)) => {
+        Some((CMD_FRONTEND, sub_matches)) => {
             let (config_path, config) = config::load_or_setup_config()?;
+            let configured_pinmame_folder = config.configured_pinmame_folder();
+            let max_depth = sub_matches
+                .get_one::<usize>(ARG_MAX_DEPTH)
+                .copied()
+                .or(config.tables_scan_max_depth);
             crate::println!("Using vpxtool config file {}", config_path.display())?;
             crate::println!("Using vpinball config file {}", config.vpx_config.display())?;
             crate::println!(
-            let configured_pinmame_folder = config.configured_pinmame_folder();
                 "Using global pinmame folder {}",
                 config.global_pinmame_folder().display()
             )?;
@@ -239,6 +244,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             match frontend::frontend_index_with_configured_pinmame(
                 &config,
                 true,
+                max_depth,
                 vec![],
                 configured_pinmame_folder.as_deref(),
             ) {
@@ -702,6 +708,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
 
 fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     let recursive = sub_matches.get_flag("RECURSIVE");
+    let max_depth_cli = sub_matches.get_one::<usize>(ARG_MAX_DEPTH).copied();
     let tables_folders_path_arg = sub_matches
         .get_one::<String>("VPXROOTPATH")
         .map(|s| s.as_str());
@@ -730,8 +737,12 @@ fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     let configured_pinmame_folder = config
         .as_ref()
         .and_then(|(_, c)| c.configured_pinmame_folder());
+    let max_depth = max_depth_cli.or(config.as_ref().and_then(|(_, c)| c.tables_scan_max_depth));
 
     crate::println!("Using tables folder {}", tables_folder_path.display())?;
+    if let Some(max_depth) = max_depth {
+        crate::println!("Using tables scan max depth {}", max_depth)?;
+    }
     match &global_pinmame_folder {
         Some(folder) => {
             crate::println!("Using global pinmame folder {}", folder.display())?;
@@ -758,6 +769,7 @@ fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     let progress = ProgressBarProgress::new(pb);
     let index = indexer::index_folder(
         recursive,
+        max_depth,
         &tables_folder_path,
         &tables_index_path,
         global_pinmame_folder.as_deref(),
@@ -850,6 +862,12 @@ fn build_command() -> Command {
                         .help("Recursively index subdirectories")
                         .default_value("true"),
                 )
+                .arg(
+                    Arg::new(ARG_MAX_DEPTH)
+                        .long("max-depth")
+                        .value_parser(clap::value_parser!(usize))
+                        .help("Maximum directory depth to scan when indexing tables"),
+                )
         )
         .subcommand(
             Command::new(CMD_INDEX)
@@ -861,6 +879,12 @@ fn build_command() -> Command {
                         .num_args(0)
                         .help("Recursively index subdirectories")
                         .default_value("true"),
+                )
+                .arg(
+                    Arg::new(ARG_MAX_DEPTH)
+                        .long("max-depth")
+                        .value_parser(clap::value_parser!(usize))
+                        .help("Maximum directory depth to scan when indexing tables"),
                 )
                 .arg(
                     arg!(<VPXROOTPATH> "The path to the root directory of vpx files. Defaults to what is set up in the vpxtool config file.")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -225,17 +225,23 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             crate::println!("Using vpxtool config file {}", config_path.display())?;
             crate::println!("Using vpinball config file {}", config.vpx_config.display())?;
             crate::println!(
+            let configured_pinmame_folder = config.configured_pinmame_folder();
                 "Using global pinmame folder {}",
                 config.global_pinmame_folder().display()
             )?;
             crate::println!(
                 "Using configured pinmame folder {}",
-                config
-                    .configured_pinmame_folder()
+                configured_pinmame_folder
+                    .as_ref()
                     .map(|f| f.display().to_string())
                     .unwrap_or_else(|| "None".to_string())
             )?;
-            match frontend::frontend_index(&config, true, vec![]) {
+            match frontend::frontend_index_with_configured_pinmame(
+                &config,
+                true,
+                vec![],
+                configured_pinmame_folder.as_deref(),
+            ) {
                 Ok(tables) if tables.is_empty() => {
                     let warning =
                         format!("No tables found in {}", config.tables_folder.display()).red();

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub vpx_executable: PathBuf,
     pub vpx_config: Option<PathBuf>,
     pub tables_folder: Option<PathBuf>,
+    pub tables_scan_max_depth: Option<usize>,
     pub diff: Option<String>,
     pub editor: Option<String>,
     pub launch_templates: Option<Vec<LaunchTemplate>>,
@@ -41,6 +42,7 @@ pub struct ResolvedConfig {
     pub vpx_config: PathBuf,
     pub tables_folder: PathBuf,
     pub tables_index_path: PathBuf,
+    pub tables_scan_max_depth: Option<usize>,
     pub diff: Option<String>,
     pub editor: Option<String>,
 }
@@ -169,6 +171,7 @@ fn read_config(config_path: &Path) -> io::Result<ResolvedConfig> {
         vpx_config,
         tables_folder: tables_folder.clone(),
         tables_index_path: tables_index_path(&tables_folder),
+        tables_scan_max_depth: config.tables_scan_max_depth,
         diff: config.diff,
         editor: config.editor,
     };
@@ -329,6 +332,7 @@ fn write_default_config(config_file: &Path, vpx_executable: &Path) -> io::Result
         launch_templates: Some(launch_templates),
         vpx_config: Some(vpx_config.clone()),
         tables_folder: Some(tables_folder.clone()),
+        tables_scan_max_depth: None,
         diff: None,
         editor: None,
     };
@@ -448,6 +452,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/home/me/tables"),
                 tables_index_path: PathBuf::from("/home/me/tables/vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
             }
@@ -498,6 +503,21 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_read_config_with_tables_scan_max_depth() -> io::Result<()> {
+        let temp_dir = testdir!();
+        let config_file = temp_dir.join(CONFIGURATION_FILE_NAME);
+        let mut file = File::create(&config_file)?;
+        file.write_all(
+            b"vpx_executable = \"/tmp/test/vpinball\"\n\
+              tables_scan_max_depth = 2\n",
+        )?;
+
+        let config = read_config(&config_file)?;
+        assert_eq!(config.tables_scan_max_depth, Some(2));
+        Ok(())
+    }
+
     // test that we can read an incomplete config file with missing tables_folder
     #[cfg(target_os = "linux")]
     #[test]
@@ -542,6 +562,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/tmp/test/tables"),
                 tables_index_path: PathBuf::from("/tmp/test/tables/vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
             }
@@ -593,6 +614,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: expected_tables_dir.clone(),
                 tables_index_path: expected_tables_dir.join("vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
             }
@@ -617,6 +639,7 @@ mod tests {
                 vpx_config: PathBuf::from("C:\\test\\VPinballX.ini"),
                 tables_folder: PathBuf::from("C:\\test\\tables"),
                 tables_index_path: PathBuf::from("C:\\test\\tables\\vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
                 launch_templates: vec!(

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -118,12 +118,14 @@ impl TableOption {
 pub fn frontend_index(
     resolved_config: &ResolvedConfig,
     recursive: bool,
+    max_depth: Option<usize>,
     force_reindex: Vec<PathBuf>,
 ) -> Result<Vec<IndexedTable>, IndexError> {
     let configured_pinmame_folder = resolved_config.configured_pinmame_folder();
     frontend_index_with_configured_pinmame(
         resolved_config,
         recursive,
+        max_depth,
         force_reindex,
         configured_pinmame_folder.as_deref(),
     )
@@ -132,6 +134,7 @@ pub fn frontend_index(
 pub fn frontend_index_with_configured_pinmame(
     resolved_config: &ResolvedConfig,
     recursive: bool,
+    max_depth: Option<usize>,
     force_reindex: Vec<PathBuf>,
     configured_pinmame_folder: Option<&Path>,
 ) -> Result<Vec<IndexedTable>, IndexError> {
@@ -145,6 +148,7 @@ pub fn frontend_index_with_configured_pinmame(
     let progress = ProgressBarProgress::new(pb);
     let index = indexer::index_folder(
         recursive,
+        max_depth,
         &resolved_config.tables_folder,
         &resolved_config.tables_index_path,
         Some(&resolved_config.global_pinmame_folder()),
@@ -259,7 +263,12 @@ fn table_menu(
                 exit = true;
             }
             Some(TableOption::ForceReload) => {
-                match frontend_index(config, true, vec![selected_path.clone()]) {
+                match frontend_index(
+                    config,
+                    true,
+                    config.tables_scan_max_depth,
+                    vec![selected_path.clone()],
+                ) {
                     Ok(index) => {
                         vpx_files_with_tableinfo.clear();
                         vpx_files_with_tableinfo.extend(index);

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -120,6 +120,21 @@ pub fn frontend_index(
     recursive: bool,
     force_reindex: Vec<PathBuf>,
 ) -> Result<Vec<IndexedTable>, IndexError> {
+    let configured_pinmame_folder = resolved_config.configured_pinmame_folder();
+    frontend_index_with_configured_pinmame(
+        resolved_config,
+        recursive,
+        force_reindex,
+        configured_pinmame_folder.as_deref(),
+    )
+}
+
+pub fn frontend_index_with_configured_pinmame(
+    resolved_config: &ResolvedConfig,
+    recursive: bool,
+    force_reindex: Vec<PathBuf>,
+    configured_pinmame_folder: Option<&Path>,
+) -> Result<Vec<IndexedTable>, IndexError> {
     let pb = ProgressBar::hidden();
     pb.set_style(
         ProgressStyle::with_template(
@@ -133,7 +148,7 @@ pub fn frontend_index(
         &resolved_config.tables_folder,
         &resolved_config.tables_index_path,
         Some(&resolved_config.global_pinmame_folder()),
-        resolved_config.configured_pinmame_folder().as_deref(),
+        configured_pinmame_folder,
         &progress,
         force_reindex,
     );

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -275,40 +275,49 @@ pub fn find_roms(rom_path: &Path) -> io::Result<HashMap<String, PathBuf>> {
     Ok(roms)
 }
 
-pub fn find_vpx_files(recursive: bool, tables_path: &Path) -> io::Result<Vec<PathWithMetadata>> {
+pub fn find_vpx_files(
+    recursive: bool,
+    max_depth: Option<usize>,
+    tables_path: &Path,
+) -> io::Result<Vec<PathWithMetadata>> {
     if recursive {
-        let mut vpx_files = Vec::new();
-        let mut entries = walk_dir_filtered(tables_path);
+        let mut vpx_paths = Vec::new();
+        let mut entries = walk_dir_filtered(tables_path, max_depth);
         entries.try_for_each(|entry| {
             let dir_entry = entry?;
-            let path = dir_entry.path();
-            if path.is_file()
-                && let Some("vpx") = path.extension().and_then(OsStr::to_str)
-            {
-                let last_modified = last_modified(path)?;
-                vpx_files.push(PathWithMetadata {
-                    path: path.to_path_buf(),
-                    last_modified,
-                });
+            if dir_entry.file_type().is_file() {
+                let path = dir_entry.path();
+                if let Some("vpx") = path.extension().and_then(OsStr::to_str) {
+                    vpx_paths.push(path.to_path_buf());
+                }
             }
             Ok::<(), io::Error>(())
         })?;
-        Ok(vpx_files)
+        vpx_paths
+            .par_iter()
+            .map(|path| {
+                let last_modified = last_modified(path)?;
+                Ok(PathWithMetadata {
+                    path: path.clone(),
+                    last_modified,
+                })
+            })
+            .collect()
     } else {
         let mut vpx_files = Vec::new();
         // TODO is there a cleaner version like try_filter_map?
         let mut dirs = fs::read_dir(tables_path)?;
         dirs.try_for_each(|entry| {
             let dir_entry = entry?;
-            let path = dir_entry.path();
-            if path.is_file()
-                && let Some("vpx") = path.extension().and_then(OsStr::to_str)
-            {
-                let last_modified = last_modified(&path)?;
-                vpx_files.push(PathWithMetadata {
-                    path: path.to_path_buf(),
-                    last_modified,
-                });
+            if dir_entry.file_type()?.is_file() {
+                let path = dir_entry.path();
+                if let Some("vpx") = path.extension().and_then(OsStr::to_str) {
+                    let last_modified = last_modified(&path)?;
+                    vpx_files.push(PathWithMetadata {
+                        path: path.to_path_buf(),
+                        last_modified,
+                    });
+                }
             }
             Ok::<(), io::Error>(())
         })?;
@@ -317,12 +326,19 @@ pub fn find_vpx_files(recursive: bool, tables_path: &Path) -> io::Result<Vec<Pat
 }
 
 /// Walks the directory and filters out .git and __MACOSX folders
-fn walk_dir_filtered(tables_path: &Path) -> FilterEntry<IntoIter, fn(&DirEntry) -> bool> {
-    WalkDir::new(tables_path).into_iter().filter_entry(|entry| {
-        let path = entry.path();
-        let git = std::path::Component::Normal(".git".as_ref());
-        let macosx = std::path::Component::Normal("__MACOSX".as_ref());
-        !path.components().any(|c| c == git) && !path.components().any(|c| c == macosx)
+fn walk_dir_filtered(
+    tables_path: &Path,
+    max_depth: Option<usize>,
+) -> FilterEntry<IntoIter, fn(&DirEntry) -> bool> {
+    let mut walkdir = WalkDir::new(tables_path);
+    if let Some(max_depth) = max_depth {
+        walkdir = walkdir.max_depth(max_depth);
+    }
+    walkdir.into_iter().filter_entry(|entry| {
+        if !entry.file_type().is_dir() {
+            return true;
+        }
+        !matches!(entry.file_name().to_str(), Some(".git" | "__MACOSX"))
     })
 }
 
@@ -380,6 +396,7 @@ impl From<io::Error> for IndexError {
 /// * `force_reindex`: a list of vpx files to reindex, even if they are not modified.
 pub fn index_folder(
     recursive: bool,
+    max_depth: Option<usize>,
     tables_folder: &Path,
     tables_index_path: &Path,
     global_pinmame_path: Option<&Path>,
@@ -403,7 +420,7 @@ pub fn index_folder(
     }
     let mut index = existing_index.unwrap_or(TablesIndex::empty());
 
-    let vpx_files = find_vpx_files(recursive, tables_folder)?;
+    let vpx_files = find_vpx_files(recursive, max_depth, tables_folder)?;
     info!("  Found {} tables", vpx_files.len());
     // remove files that are missing
     let removed_len = index.remove_missing(&vpx_files);
@@ -838,7 +855,7 @@ mod tests {
         // let output_str = String::from_utf8_lossy(&output.stdout);
         // println!("global_pinmame_dir:\n{}", output_str);
 
-        let vpx_files = find_vpx_files(true, &tables_dir)?;
+        let vpx_files = find_vpx_files(true, None, &tables_dir)?;
         assert_eq!(vpx_files.len(), 3);
         let global_roms = find_roms(&global_roms_dir)?;
         assert_eq!(global_roms.len(), 1);
@@ -887,7 +904,7 @@ mod tests {
         vpx::new_minimal_vpx(&vpx_a_path)?;
         vpx::new_minimal_vpx(&vpx_m_path)?;
 
-        let vpx_files = find_vpx_files(true, &tables_dir)?;
+        let vpx_files = find_vpx_files(true, None, &tables_dir)?;
         let indexed = index_vpx_files(vpx_files, None, None, &VoidProgress)?;
 
         let json: TablesIndexJson = indexed.into();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -26,12 +26,10 @@ pub const DEFAULT_INDEX_FILE_NAME: &str = "vpxtool_index.json";
 
 // Compile regexes once to avoid per-table startup cost while indexing large collections.
 static LINE_WITH_CGAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r#"(?i)(?:.*?)*cgamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#)
-        .unwrap()
+    regex::Regex::new(r#"(?i)(?:.*?)*cgamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#).unwrap()
 });
 static LINE_WITH_DOT_GAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r#"(?i)(?:.*?)\.gamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#)
-        .unwrap()
+    regex::Regex::new(r#"(?i)(?:.*?)\.gamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#).unwrap()
 });
 static LOADVPM_SUB_REGEX: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r#"sub\s*loadvpm"#).unwrap());
@@ -246,8 +244,7 @@ impl From<TablesIndexJson> for TablesIndex {
 
 /// Convert a platform-specific path to a normalized string using forward slashes.
 fn to_normalized_path(path: &Path) -> String {
-    path.to_string_lossy()
-        .replace('\\', "/")
+    path.to_string_lossy().replace('\\', "/")
 }
 
 /// Convert a normalized path string using forward slashes back to a platform-specific PathBuf.
@@ -446,6 +443,7 @@ impl From<io::Error> for IndexError {
 /// * `configured_pinmame_path`: the path to the local pinmame folder configured in the vpinball config.
 /// * `progress`: lister for progress updates.
 /// * `force_reindex`: a list of vpx files to reindex, even if they are not modified.
+#[allow(clippy::too_many_arguments)]
 pub fn index_folder(
     recursive: bool,
     max_depth: Option<usize>,
@@ -763,24 +761,28 @@ fn consider_sidecar_vbs(path: &Path, game_data: GameData) -> io::Result<String> 
 fn normalize_index_for_json(index: &TablesIndex, tables_root: &Path) -> TablesIndex {
     let normalized_tables: HashMap<PathBuf, IndexedTable> = index
         .tables
-        .iter()
-        .map(|(_, table)| {
+        .values()
+        .map(|table| {
             let normalized_table = IndexedTable {
                 path: PathBuf::from(try_make_relative_normalized(&table.path, tables_root)),
                 table_info: table.table_info.clone(),
                 game_name: table.game_name.clone(),
-                b2s_path: table.b2s_path.as_ref().map(|p| {
-                    PathBuf::from(try_make_relative_normalized(p, tables_root))
-                }),
-                rom_path: table.rom_path.as_ref().map(|p| {
-                    PathBuf::from(try_make_relative_normalized(p, tables_root))
-                }),
-                local_rom_path: table.local_rom_path.as_ref().map(|p| {
-                    PathBuf::from(try_make_relative_normalized(p, tables_root))
-                }),
-                wheel_path: table.wheel_path.as_ref().map(|p| {
-                    PathBuf::from(try_make_relative_normalized(p, tables_root))
-                }),
+                b2s_path: table
+                    .b2s_path
+                    .as_ref()
+                    .map(|p| PathBuf::from(try_make_relative_normalized(p, tables_root))),
+                rom_path: table
+                    .rom_path
+                    .as_ref()
+                    .map(|p| PathBuf::from(try_make_relative_normalized(p, tables_root))),
+                local_rom_path: table
+                    .local_rom_path
+                    .as_ref()
+                    .map(|p| PathBuf::from(try_make_relative_normalized(p, tables_root))),
+                wheel_path: table
+                    .wheel_path
+                    .as_ref()
+                    .map(|p| PathBuf::from(try_make_relative_normalized(p, tables_root))),
                 requires_pinmame: table.requires_pinmame,
                 last_modified: table.last_modified,
             };
@@ -796,24 +798,28 @@ fn normalize_index_for_json(index: &TablesIndex, tables_root: &Path) -> TablesIn
 fn denormalize_index_from_json(index: &TablesIndex, tables_root: Option<&Path>) -> TablesIndex {
     let denormalized_tables: HashMap<PathBuf, IndexedTable> = index
         .tables
-        .iter()
-        .map(|(_, table)| {
+        .values()
+        .map(|table| {
             let denormalized_table = IndexedTable {
                 path: resolve_normalized_path(&table.path.to_string_lossy(), tables_root),
                 table_info: table.table_info.clone(),
                 game_name: table.game_name.clone(),
-                b2s_path: table.b2s_path.as_ref().map(|p| {
-                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
-                }),
-                rom_path: table.rom_path.as_ref().map(|p| {
-                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
-                }),
-                local_rom_path: table.local_rom_path.as_ref().map(|p| {
-                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
-                }),
-                wheel_path: table.wheel_path.as_ref().map(|p| {
-                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
-                }),
+                b2s_path: table
+                    .b2s_path
+                    .as_ref()
+                    .map(|p| resolve_normalized_path(&p.to_string_lossy(), tables_root)),
+                rom_path: table
+                    .rom_path
+                    .as_ref()
+                    .map(|p| resolve_normalized_path(&p.to_string_lossy(), tables_root)),
+                local_rom_path: table
+                    .local_rom_path
+                    .as_ref()
+                    .map(|p| resolve_normalized_path(&p.to_string_lossy(), tables_root)),
+                wheel_path: table
+                    .wheel_path
+                    .as_ref()
+                    .map(|p| resolve_normalized_path(&p.to_string_lossy(), tables_root)),
                 requires_pinmame: table.requires_pinmame,
                 last_modified: table.last_modified,
             };

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::Metadata;
 use std::io::Read;
+use std::sync::LazyLock;
 use std::time::SystemTime;
 use std::{
     ffi::OsStr,
@@ -22,6 +23,18 @@ use walkdir::{DirEntry, FilterEntry, IntoIter, WalkDir};
 use vpx::gamedata::GameData;
 
 pub const DEFAULT_INDEX_FILE_NAME: &str = "vpxtool_index.json";
+
+// Compile regexes once to avoid per-table startup cost while indexing large collections.
+static LINE_WITH_CGAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"(?i)(?:.*?)*cgamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#)
+        .unwrap()
+});
+static LINE_WITH_DOT_GAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"(?i)(?:.*?)\.gamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#)
+        .unwrap()
+});
+static LOADVPM_SUB_REGEX: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"sub\s*loadvpm"#).unwrap());
 
 /// Introduced because we want full control over serialization
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -455,13 +468,6 @@ pub fn index_vpx_files(
     configured_pinmame_path: Option<&Path>,
     progress: &impl Progress,
 ) -> io::Result<TablesIndex> {
-    let global_roms = global_pinmame_path
-        .map(|pinmame_path| {
-            let roms_path = pinmame_path.join("roms");
-            find_roms(&roms_path)
-        })
-        .unwrap_or_else(|| Ok(HashMap::new()))?;
-
     let pinmame_roms_path = configured_pinmame_path.map(|p| p.join("roms").to_path_buf());
 
     let (progress_tx, progress_rx) = std::sync::mpsc::channel();
@@ -471,8 +477,7 @@ pub fn index_vpx_files(
         vpx_files
             .par_iter()
             .flat_map(|vpx_file| {
-                let res = match index_vpx_file(vpx_file, pinmame_roms_path.as_deref(), &global_roms)
-                {
+                let res = match index_vpx_file(vpx_file, pinmame_roms_path.as_deref()) {
                     Ok(indexed_table) => Some(indexed_table),
                     Err(e) => {
                         // TODO we want to return any failures instead of printing here
@@ -497,9 +502,37 @@ pub fn index_vpx_files(
         progress.set_position(finished);
     }
 
-    let vpx_files_with_table_info = index_thread
+    let mut vpx_files_with_table_info: HashMap<PathBuf, IndexedTable> = index_thread
         .join()
         .map_err(|e| io::Error::other(format!("{e:?}")))?;
+
+    let needs_global_lookup = global_pinmame_path.is_some()
+        && vpx_files_with_table_info
+            .values()
+            .any(|table| table.game_name.is_some() && table.rom_path().is_none());
+
+    if needs_global_lookup {
+        let global_roms = global_pinmame_path
+            .map(|pinmame_path| {
+                let roms_path = pinmame_path.join("roms");
+                find_roms(&roms_path)
+            })
+            .unwrap_or_else(|| Ok(HashMap::new()))?;
+
+        let mut resolved_with_global = 0usize;
+        for table in vpx_files_with_table_info.values_mut() {
+            if table.rom_path().is_none()
+                && let Some(game_name) = table.game_name.as_ref()
+                && let Some(global_rom_path) = global_roms.get(&game_name.to_lowercase())
+            {
+                table.rom_path = Some(global_rom_path.clone());
+                resolved_with_global += 1;
+            }
+        }
+        info!("  Resolved {resolved_with_global} table roms from global pinmame roms");
+    } else {
+        info!("  Skipped global rom scan (no unresolved pinmame table roms)");
+    }
 
     Ok(TablesIndex {
         tables: vpx_files_with_table_info,
@@ -509,7 +542,6 @@ pub fn index_vpx_files(
 fn index_vpx_file(
     vpx_file_path: &PathWithMetadata,
     configured_roms_path: Option<&Path>,
-    global_roms: &HashMap<String, PathBuf>,
 ) -> io::Result<(PathBuf, IndexedTable)> {
     let path = &vpx_file_path.path;
     let mut vpx_file = vpx::open(path)?;
@@ -525,11 +557,7 @@ fn index_vpx_file(
     //  also this sidecar should be part of the cache key
     let game_name = extract_game_name(&code);
     let requires_pinmame = requires_pinmame(&code);
-    let rom_path = find_local_rom_path(path, &game_name, configured_roms_path)?.or_else(|| {
-        game_name
-            .as_ref()
-            .and_then(|game_name| global_roms.get(&game_name.to_lowercase()).cloned())
-    });
+    let rom_path = find_local_rom_path(path, &game_name, configured_roms_path)?;
     let b2s_path = find_b2s_path(path);
     let wheel_path = find_wheel_path(path);
     let last_modified = last_modified(path)?;
@@ -689,14 +717,6 @@ pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {
 }
 
 fn extract_game_name<S: AsRef<str>>(code: S) -> Option<String> {
-    // TODO can we find a first match through an option?
-    // needs to be all lowercase to match with (?i) case insensitive
-    const LINE_WITH_CGAMENAME_RE: &str =
-        r#"(?i)(?:.*?)*cgamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#;
-    const LINE_WITH_DOT_GAMENAME_RE: &str =
-        r#"(?i)(?:.*?)\.gamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#;
-    let cgamename_re = regex::Regex::new(LINE_WITH_CGAMENAME_RE).unwrap();
-    let dot_gamename_re = regex::Regex::new(LINE_WITH_DOT_GAMENAME_RE).unwrap();
     let unified = unify_line_endings(code.as_ref());
     unified
         .lines()
@@ -707,9 +727,9 @@ fn extract_game_name<S: AsRef<str>>(code: S) -> Option<String> {
             lower.contains("cgamename") || lower.contains(".gamename")
         })
         .flat_map(|line| {
-            let caps = cgamename_re
+            let caps = LINE_WITH_CGAMENAME_REGEX
                 .captures(line)
-                .or(dot_gamename_re.captures(line))?;
+                .or(LINE_WITH_DOT_GAMENAME_REGEX.captures(line))?;
             let first = caps.get(1)?;
             Some(first.as_str().to_string())
         })
@@ -719,12 +739,10 @@ fn extract_game_name<S: AsRef<str>>(code: S) -> Option<String> {
 fn requires_pinmame<S: AsRef<str>>(code: S) -> bool {
     let unified = unify_line_endings(code.as_ref());
     let lower = unified.to_lowercase();
-    const RE: &str = r#"sub\s*loadvpm"#;
-    let re = regex::Regex::new(RE).unwrap();
     lower
         .lines()
         .filter(|line| !line.trim().starts_with('\''))
-        .any(|line| line.contains("loadvpm") && !re.is_match(line))
+        .any(|line| line.contains("loadvpm") && !LOADVPM_SUB_REGEX.is_match(line))
 }
 
 /// Some scripts contain only CR as line separator. Eg "Monte Carlo (Premier 1987) (10.7) 1.6.vpx"

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -133,7 +133,7 @@ impl IndexedTable {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct TablesIndex {
     tables: HashMap<PathBuf, IndexedTable>,
 }
@@ -241,6 +241,58 @@ impl From<TablesIndexJson> for TablesIndex {
             tables.insert(table.path.clone(), table);
         }
         TablesIndex { tables }
+    }
+}
+
+/// Convert a platform-specific path to a normalized string using forward slashes.
+fn to_normalized_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Convert a normalized path string using forward slashes back to a platform-specific PathBuf.
+fn from_normalized_path(normalized: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        PathBuf::from(normalized.replace('/', "\\"))
+    }
+    #[cfg(not(windows))]
+    {
+        PathBuf::from(normalized)
+    }
+}
+
+/// Try to make a path relative to a base path. Returns a normalized string using forward slashes.
+/// If the path is not under base, returns the normalized absolute path.
+/// Canonicalizes both paths first to handle different representations (e.g., mapped drives vs UNC paths).
+fn try_make_relative_normalized(path: &Path, base: &Path) -> String {
+    // Try to canonicalize both paths to normalize different representations (mapped drive vs UNC)
+    let canonical_path = path.canonicalize().ok();
+    let canonical_base = base.canonicalize().ok();
+
+    // Use canonical versions if available for comparison, otherwise use originals
+    let path_to_check = canonical_path.as_deref().unwrap_or(path);
+    let base_to_check = canonical_base.as_deref().unwrap_or(base);
+
+    if let Ok(relative) = path_to_check.strip_prefix(base_to_check) {
+        to_normalized_path(relative)
+    } else {
+        // Use canonical path if available, otherwise use original
+        let display_path = canonical_path.as_deref().unwrap_or(path);
+        to_normalized_path(display_path)
+    }
+}
+
+/// Resolve a normalized path string to an absolute PathBuf.
+/// If the path is absolute, uses it directly. Otherwise, joins with base.
+fn resolve_normalized_path(normalized: &str, base: Option<&Path>) -> PathBuf {
+    let path = from_normalized_path(normalized);
+    if path.is_absolute() {
+        path
+    } else if let Some(base_path) = base {
+        base_path.join(path)
+    } else {
+        path
     }
 }
 
@@ -410,7 +462,7 @@ pub fn index_folder(
         return Err(IndexError::FolderDoesNotExist(tables_folder.to_path_buf()));
     }
 
-    let existing_index = read_index_json(tables_index_path)?;
+    let existing_index = read_index_json(tables_index_path, Some(tables_folder))?;
     if let Some(index) = &existing_index {
         info!(
             "  Found existing index with {} tables at {}",
@@ -464,7 +516,7 @@ pub fn index_folder(
     index.merge(vpx_files_with_table_info);
 
     // write the index to a file
-    write_index_json(&index, tables_index_path)?;
+    write_index_json(&index, tables_index_path, Some(tables_folder))?;
 
     Ok(index)
 }
@@ -707,19 +759,96 @@ fn consider_sidecar_vbs(path: &Path, game_data: GameData) -> io::Result<String> 
     Ok(code)
 }
 
+/// Normalize paths in an index to be relative to tables_root using forward slashes.
+fn normalize_index_for_json(index: &TablesIndex, tables_root: &Path) -> TablesIndex {
+    let normalized_tables: HashMap<PathBuf, IndexedTable> = index
+        .tables
+        .iter()
+        .map(|(_, table)| {
+            let normalized_table = IndexedTable {
+                path: PathBuf::from(try_make_relative_normalized(&table.path, tables_root)),
+                table_info: table.table_info.clone(),
+                game_name: table.game_name.clone(),
+                b2s_path: table.b2s_path.as_ref().map(|p| {
+                    PathBuf::from(try_make_relative_normalized(p, tables_root))
+                }),
+                rom_path: table.rom_path.as_ref().map(|p| {
+                    PathBuf::from(try_make_relative_normalized(p, tables_root))
+                }),
+                local_rom_path: table.local_rom_path.as_ref().map(|p| {
+                    PathBuf::from(try_make_relative_normalized(p, tables_root))
+                }),
+                wheel_path: table.wheel_path.as_ref().map(|p| {
+                    PathBuf::from(try_make_relative_normalized(p, tables_root))
+                }),
+                requires_pinmame: table.requires_pinmame,
+                last_modified: table.last_modified,
+            };
+            (normalized_table.path.clone(), normalized_table)
+        })
+        .collect();
+    TablesIndex {
+        tables: normalized_tables,
+    }
+}
+
+/// Denormalize paths in an index from using forward slashes to absolute platform-specific paths.
+fn denormalize_index_from_json(index: &TablesIndex, tables_root: Option<&Path>) -> TablesIndex {
+    let denormalized_tables: HashMap<PathBuf, IndexedTable> = index
+        .tables
+        .iter()
+        .map(|(_, table)| {
+            let denormalized_table = IndexedTable {
+                path: resolve_normalized_path(&table.path.to_string_lossy(), tables_root),
+                table_info: table.table_info.clone(),
+                game_name: table.game_name.clone(),
+                b2s_path: table.b2s_path.as_ref().map(|p| {
+                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
+                }),
+                rom_path: table.rom_path.as_ref().map(|p| {
+                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
+                }),
+                local_rom_path: table.local_rom_path.as_ref().map(|p| {
+                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
+                }),
+                wheel_path: table.wheel_path.as_ref().map(|p| {
+                    resolve_normalized_path(&p.to_string_lossy(), tables_root)
+                }),
+                requires_pinmame: table.requires_pinmame,
+                last_modified: table.last_modified,
+            };
+            (denormalized_table.path.clone(), denormalized_table)
+        })
+        .collect();
+    TablesIndex {
+        tables: denormalized_tables,
+    }
+}
+
 fn last_modified(path: &Path) -> io::Result<SystemTime> {
     let metadata: Metadata = path.metadata()?;
     metadata.modified()
 }
 
-pub fn write_index_json(indexed_tables: &TablesIndex, json_path: &Path) -> io::Result<()> {
+pub fn write_index_json(
+    indexed_tables: &TablesIndex,
+    json_path: &Path,
+    tables_root: Option<&Path>,
+) -> io::Result<()> {
+    let normalized_index = match tables_root {
+        Some(root) => normalize_index_for_json(indexed_tables, root),
+        None => indexed_tables.clone(),
+    };
     let json_file = File::create(json_path)?;
     let writer = BufWriter::new(json_file);
-    let indexed_tables_json: TablesIndexJson = indexed_tables.into();
+    let indexed_tables_json: TablesIndexJson = (&normalized_index).into();
     serde_json::to_writer_pretty(writer, &indexed_tables_json).map_err(io::Error::other)
 }
 
-pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {
+pub fn read_index_json(
+    json_path: &Path,
+    tables_root: Option<&Path>,
+) -> io::Result<Option<TablesIndex>> {
     if !json_path.exists() {
         return Ok(None);
     }
@@ -728,7 +857,8 @@ pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {
     match serde_json::from_reader::<_, TablesIndexJson>(reader) {
         Ok(indexed_tables_json) => {
             let indexed_tables: TablesIndex = indexed_tables_json.into();
-            Ok(Some(indexed_tables))
+            let denormalized_index = denormalize_index_from_json(&indexed_tables, tables_root);
+            Ok(Some(denormalized_index))
         }
         Err(e) => {
             println!("Failed to parse index file, ignoring existing index. ({e})");

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1082,7 +1082,7 @@ mod tests {
             "tables": []
         });
         serde_json::to_writer_pretty(json_file, &json_object)?;
-        let read = read_index_json(&index_path)?;
+        let read = read_index_json(&index_path, None)?;
         assert_eq!(read, Some(index));
         Ok(())
     }
@@ -1095,7 +1095,7 @@ mod tests {
         let json_file = File::create(&index_path)?;
         // write garbage to file
         serde_json::to_writer_pretty(json_file, &"garbage")?;
-        let read = read_index_json(&index_path)?;
+        let read = read_index_json(&index_path, None)?;
         assert_eq!(read, None);
         Ok(())
     }
@@ -1105,8 +1105,8 @@ mod tests {
         let index = TablesIndex::empty();
         let test_dir = testdir!();
         let index_path = test_dir.join("test.json");
-        write_index_json(&index, &index_path)?;
-        let read = read_index_json(&index_path)?;
+        write_index_json(&index, &index_path, None)?;
+        let read = read_index_json(&index_path, None)?;
         assert_eq!(read, Some(index));
         Ok(())
     }
@@ -1128,7 +1128,7 @@ mod tests {
                 author_website: None,
                 table_save_date: None,
                 table_description: None,
-                properties: HashMap::new(),
+                properties: BTreeMap::new(),
             },
             game_name: Some("testrom".to_string()),
             b2s_path: Some(PathBuf::from("test.b2s")),
@@ -1140,8 +1140,8 @@ mod tests {
         });
         let test_dir = testdir!();
         let index_path = test_dir.join("test.json");
-        write_index_json(&index, &index_path)?;
-        let read = read_index_json(&index_path)?;
+        write_index_json(&index, &index_path, None)?;
+        let read = read_index_json(&index_path, None)?;
         assert_eq!(read, Some(index));
         Ok(())
     }
@@ -1149,7 +1149,7 @@ mod tests {
     #[test]
     fn test_read_index_missing() -> io::Result<()> {
         let index_path = PathBuf::from("missing_index_file.json");
-        let read = read_index_json(&index_path)?;
+        let read = read_index_json(&index_path, None)?;
         assert_eq!(read, None);
         Ok(())
     }
@@ -1386,7 +1386,7 @@ LoadVPM "01210000","sys80.vbs",3.10
                 author_website: None,
                 table_save_date: None,
                 table_description: None,
-                properties: HashMap::new(),
+                properties: BTreeMap::new(),
             },
             game_name: None,
             b2s_path: None,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::Metadata;
-use std::io::Read;
+use std::io::{BufReader, BufWriter, Read};
 use std::sync::LazyLock;
 use std::time::SystemTime;
 use std::{
@@ -608,8 +608,9 @@ pub fn get_romname_from_vpx(vpx_path: &Path) -> io::Result<Option<String>> {
 }
 
 fn read_table_info_json(info_file_path: &Path) -> io::Result<TableInfo> {
-    let mut info_file = File::open(info_file_path)?;
-    let json = serde_json::from_reader(&mut info_file).map_err(|e| {
+    let info_file = File::open(info_file_path)?;
+    let reader = BufReader::new(info_file);
+    let json = serde_json::from_reader(reader).map_err(|e| {
         io::Error::other(format!(
             "Failed to parse/read json {}: {}",
             info_file_path.display(),
@@ -695,9 +696,10 @@ fn find_wheel_path(vpx_file_path: &Path) -> Option<PathBuf> {
 fn consider_sidecar_vbs(path: &Path, game_data: GameData) -> io::Result<String> {
     let vbs_path = path.with_extension("vbs");
     let code = if vbs_path.exists() {
-        let mut vbs_file = File::open(vbs_path)?;
+        let vbs_file = File::open(vbs_path)?;
+        let mut reader = BufReader::new(vbs_file);
         let mut code = String::new();
-        vbs_file.read_to_string(&mut code)?;
+        reader.read_to_string(&mut code)?;
         code
     } else {
         game_data.code.string
@@ -712,8 +714,9 @@ fn last_modified(path: &Path) -> io::Result<SystemTime> {
 
 pub fn write_index_json(indexed_tables: &TablesIndex, json_path: &Path) -> io::Result<()> {
     let json_file = File::create(json_path)?;
+    let writer = BufWriter::new(json_file);
     let indexed_tables_json: TablesIndexJson = indexed_tables.into();
-    serde_json::to_writer_pretty(json_file, &indexed_tables_json).map_err(io::Error::other)
+    serde_json::to_writer_pretty(writer, &indexed_tables_json).map_err(io::Error::other)
 }
 
 pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {
@@ -721,7 +724,8 @@ pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {
         return Ok(None);
     }
     let json_file = File::open(json_path)?;
-    match serde_json::from_reader::<_, TablesIndexJson>(json_file) {
+    let reader = BufReader::new(json_file);
+    match serde_json::from_reader::<_, TablesIndexJson>(reader) {
         Ok(indexed_tables_json) => {
             let indexed_tables: TablesIndex = indexed_tables_json.into();
             Ok(Some(indexed_tables))

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use log::info;
 use rayon::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::Metadata;
@@ -212,22 +211,9 @@ impl From<&TablesIndex> for TablesIndexJson {
 }
 
 fn sort_tables(mut tables: Vec<IndexedTable>) -> Vec<IndexedTable> {
-    tables.sort_by(|a, b| {
-        let name_order = match (
-            a.table_info.table_name.as_deref(),
-            b.table_info.table_name.as_deref(),
-        ) {
-            (Some(a_name), Some(b_name)) => a_name.to_lowercase().cmp(&b_name.to_lowercase()),
-            (Some(_), None) => Ordering::Less,
-            (None, Some(_)) => Ordering::Greater,
-            (None, None) => Ordering::Equal,
-        };
-
-        if name_order == Ordering::Equal {
-            a.path.file_name().cmp(&b.path.file_name())
-        } else {
-            name_order
-        }
+    tables.sort_by_cached_key(|table| {
+        let normalized_path = to_normalized_path(&table.path);
+        (normalized_path.to_lowercase(), normalized_path)
     });
     tables
 }
@@ -1399,33 +1385,27 @@ LoadVPM "01210000","sys80.vbs",3.10
     }
 
     #[test]
-    fn test_sort_tables_by_name_case_insensitive() {
+    fn test_sort_tables_by_normalized_path_case_insensitive() {
         let tables = vec![
-            make_indexed_table("c.vpx", Some("Zeta")),
-            make_indexed_table("b.vpx", Some("alpha")),
-            make_indexed_table("a.vpx", Some("Beta")),
+            make_indexed_table("C/third.vpx", Some("Zeta")),
+            make_indexed_table("b/second.vpx", Some("alpha")),
+            make_indexed_table("A/first.vpx", Some("Beta")),
         ];
         let sorted = sort_tables(tables);
-        let names: Vec<_> = sorted
-            .iter()
-            .map(|t| t.table_info.table_name.as_deref())
-            .collect();
-        assert_eq!(names, vec![Some("alpha"), Some("Beta"), Some("Zeta")]);
+        let paths: Vec<_> = sorted.iter().map(|t| t.path.to_str().unwrap()).collect();
+        assert_eq!(paths, vec!["A/first.vpx", "b/second.vpx", "C/third.vpx"]);
     }
 
     #[test]
-    fn test_sort_tables_none_names_sort_last() {
+    fn test_sort_tables_ignores_table_name() {
         let tables = vec![
-            make_indexed_table("b.vpx", None),
-            make_indexed_table("a.vpx", Some("Alpha")),
-            make_indexed_table("c.vpx", None),
+            make_indexed_table("z.vpx", Some("Alpha")),
+            make_indexed_table("a.vpx", None),
+            make_indexed_table("m.vpx", Some("Omega")),
         ];
         let sorted = sort_tables(tables);
-        let names: Vec<_> = sorted
-            .iter()
-            .map(|t| t.table_info.table_name.as_deref())
-            .collect();
-        assert_eq!(names, vec![Some("Alpha"), None, None]);
+        let paths: Vec<_> = sorted.iter().map(|t| t.path.to_str().unwrap()).collect();
+        assert_eq!(paths, vec!["a.vpx", "m.vpx", "z.vpx"]);
     }
 
     #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -3,7 +3,7 @@ use log::info;
 use rayon::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::Metadata;
 use std::io::{BufReader, BufWriter, Read};
@@ -50,7 +50,7 @@ pub struct IndexedTableInfo {
     pub table_save_date: Option<String>,
     pub table_description: Option<String>,
     // the keys (and ordering) for these are defined in "GameStg/CustomInfoTags"
-    pub properties: HashMap<String, String>,
+    pub properties: BTreeMap<String, String>,
 }
 impl From<TableInfo> for IndexedTableInfo {
     fn from(table_info: TableInfo) -> Self {
@@ -67,7 +67,7 @@ impl From<TableInfo> for IndexedTableInfo {
             author_website: table_info.author_website,
             table_save_date: table_info.table_save_date,
             table_description: table_info.table_description,
-            properties: table_info.properties,
+            properties: table_info.properties.into_iter().collect(),
         }
     }
 }


### PR DESCRIPTION
## Summary

A collection of performance improvements focused on reducing startup and scan time when using `vpxtool index` and `vpxtool frontend` over a NAS share.

## Changes

### Improve index performance

Several changes to speed up the indexing pipeline:

- **Lazy ROM scan** — ROM path resolution is skipped unless the table requires PinMAME
- **Regex caching** — Compiled regexes are cached using `LazyLock` instead of being recompiled on each use
- **Parallel mtime fetch** — Last-modified timestamps for all `.vpx` files are fetched in parallel using `rayon`

### Add configurable tables scan max depth

A new `tables_scan_max_depth` option can be set in the config file to limit how many directory levels are walked during table discovery. This is useful when tables are all at a known shallow depth, avoiding deep recursion into unrelated subdirectories.
The `--max-depth` flag on the `frontend` and `index` commands also allows overriding the value at runtime.

### Use buffered I/O to avoid NAS round-trips

All file reads and writes (index JSON, VPX files, config files) now go through `BufReader`/`BufWriter`. This reduces the number of network round-trips on NAS-backed filesystems by batching small reads into larger sequential ones.

### Store index paths as relative and normalized

Paths stored in `vpxtool_index.json` are now:

- **Relative to the tables root** when possible, instead of absolute.
- **Forward-slash separated** on all platforms, making the index file portable when shared via a NAS.

Paths outside the tables root are stored as absolute with forward slashes. On read, paths are resolved back to platform-specific absolute paths.

This also correctly handles Windows mapped drives vs UNC paths (e.g. `Z:\Pinball\Tables` vs. `\\server\share\...`) by canonicalizing both sides before comparison.

### Make table metadata property ordering deterministic

The `table_info.properties` map in the generated index now uses deterministic key ordering so the serialized JSON is stable across runs and platforms.
