### PR TITLE
perf: use regex caching for game name and pinmame detection

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::Metadata;
 use std::io::Read;
+use std::sync::LazyLock;
 use std::time::SystemTime;
 use std::{
     ffi::OsStr,
@@ -22,6 +23,16 @@ use walkdir::{DirEntry, FilterEntry, IntoIter, WalkDir};
 use vpx::gamedata::GameData;
 
 pub const DEFAULT_INDEX_FILE_NAME: &str = "vpxtool_index.json";
+
+// Compile regexes once to avoid per-table startup cost while indexing large collections.
+static LINE_WITH_CGAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"(?i)(?:.*?)*cgamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#).unwrap()
+});
+static LINE_WITH_DOT_GAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"(?i)(?:.*?)\.gamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#).unwrap()
+});
+static LOADVPM_SUB_REGEX: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"sub\s*loadvpm"#).unwrap());
 
 /// Introduced because we want full control over serialization
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -689,14 +700,6 @@ pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {
 }
 
 fn extract_game_name<S: AsRef<str>>(code: S) -> Option<String> {
-    // TODO can we find a first match through an option?
-    // needs to be all lowercase to match with (?i) case insensitive
-    const LINE_WITH_CGAMENAME_RE: &str =
-        r#"(?i)(?:.*?)*cgamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#;
-    const LINE_WITH_DOT_GAMENAME_RE: &str =
-        r#"(?i)(?:.*?)\.gamename\s*=\s*\"([^"\\]*(?:\\.[^"\\]*)*)\""#;
-    let cgamename_re = regex::Regex::new(LINE_WITH_CGAMENAME_RE).unwrap();
-    let dot_gamename_re = regex::Regex::new(LINE_WITH_DOT_GAMENAME_RE).unwrap();
     let unified = unify_line_endings(code.as_ref());
     unified
         .lines()
@@ -707,9 +710,9 @@ fn extract_game_name<S: AsRef<str>>(code: S) -> Option<String> {
             lower.contains("cgamename") || lower.contains(".gamename")
         })
         .flat_map(|line| {
-            let caps = cgamename_re
+            let caps = LINE_WITH_CGAMENAME_REGEX
                 .captures(line)
-                .or(dot_gamename_re.captures(line))?;
+                .or(LINE_WITH_DOT_GAMENAME_REGEX.captures(line))?;
             let first = caps.get(1)?;
             Some(first.as_str().to_string())
         })
@@ -719,12 +722,10 @@ fn extract_game_name<S: AsRef<str>>(code: S) -> Option<String> {
 fn requires_pinmame<S: AsRef<str>>(code: S) -> bool {
     let unified = unify_line_endings(code.as_ref());
     let lower = unified.to_lowercase();
-    const RE: &str = r#"sub\s*loadvpm"#;
-    let re = regex::Regex::new(RE).unwrap();
     lower
         .lines()
         .filter(|line| !line.trim().starts_with('\''))
-        .any(|line| line.contains("loadvpm") && !re.is_match(line))
+        .any(|line| line.contains("loadvpm") && !LOADVPM_SUB_REGEX.is_match(line))
 }
 
 /// Some scripts contain only CR as line separator. Eg "Monte Carlo (Premier 1987) (10.7) 1.6.vpx"


### PR DESCRIPTION
Moves the three regexes used during table indexing (`cgamename`, `.gamename`, `loadvpm` sub detection) from per-call `regex::Regex::new(...)` to `static LazyLock<regex::Regex>` constants. This avoids recompiling them for every table in the collection.