### PR TITLE
feat: add configurable tables scan max depth

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,6 +86,7 @@ const CMD_ROMNAME: &str = "romname";
 
 const CMD_INDEX: &str = "index";
 const ARG_VERBOSE: &str = "VERBOSE";
+const ARG_MAX_DEPTH: &str = "MAX_DEPTH";
 
 pub(crate) struct ProgressBarProgress {
     pb: ProgressBar,
@@ -220,8 +221,12 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 }
             }
         }
-        Some((CMD_FRONTEND, _sub_matches)) => {
+        Some((CMD_FRONTEND, sub_matches)) => {
             let (config_path, config) = config::load_or_setup_config()?;
+            let max_depth = sub_matches
+                .get_one::<usize>(ARG_MAX_DEPTH)
+                .copied()
+                .or(config.tables_scan_max_depth);
             crate::println!("Using vpxtool config file {}", config_path.display())?;
             crate::println!("Using vpinball config file {}", config.vpx_config.display())?;
             crate::println!(
@@ -235,7 +240,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     .map(|f| f.display().to_string())
                     .unwrap_or_else(|| "None".to_string())
             )?;
-            match frontend::frontend_index(&config, true, vec![]) {
+            match frontend::frontend_index(&config, true, max_depth, vec![]) {
                 Ok(tables) if tables.is_empty() => {
                     let warning =
                         format!("No tables found in {}", config.tables_folder.display()).red();
@@ -696,6 +701,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
 
 fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     let recursive = sub_matches.get_flag("RECURSIVE");
+    let max_depth_cli = sub_matches.get_one::<usize>(ARG_MAX_DEPTH).copied();
     let tables_folders_path_arg = sub_matches
         .get_one::<String>("VPXROOTPATH")
         .map(|s| s.as_str());
@@ -724,8 +730,12 @@ fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     let configured_pinmame_folder = config
         .as_ref()
         .and_then(|(_, c)| c.configured_pinmame_folder());
+    let max_depth = max_depth_cli.or(config.as_ref().and_then(|(_, c)| c.tables_scan_max_depth));
 
     crate::println!("Using tables folder {}", tables_folder_path.display())?;
+    if let Some(max_depth) = max_depth {
+        crate::println!("Using tables scan max depth {}", max_depth)?;
+    }
     match &global_pinmame_folder {
         Some(folder) => {
             crate::println!("Using global pinmame folder {}", folder.display())?;
@@ -752,6 +762,7 @@ fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     let progress = ProgressBarProgress::new(pb);
     let index = indexer::index_folder(
         recursive,
+        max_depth,
         &tables_folder_path,
         &tables_index_path,
         global_pinmame_folder.as_deref(),
@@ -844,6 +855,12 @@ fn build_command() -> Command {
                         .help("Recursively index subdirectories")
                         .default_value("true"),
                 )
+                .arg(
+                    Arg::new(ARG_MAX_DEPTH)
+                        .long("max-depth")
+                        .value_parser(clap::value_parser!(usize))
+                        .help("Maximum directory depth to scan when indexing tables"),
+                )
         )
         .subcommand(
             Command::new(CMD_INDEX)
@@ -855,6 +872,12 @@ fn build_command() -> Command {
                         .num_args(0)
                         .help("Recursively index subdirectories")
                         .default_value("true"),
+                )
+                .arg(
+                    Arg::new(ARG_MAX_DEPTH)
+                        .long("max-depth")
+                        .value_parser(clap::value_parser!(usize))
+                        .help("Maximum directory depth to scan when indexing tables"),
                 )
                 .arg(
                     arg!(<VPXROOTPATH> "The path to the root directory of vpx files. Defaults to what is set up in the vpxtool config file.")

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub vpx_executable: PathBuf,
     pub vpx_config: Option<PathBuf>,
     pub tables_folder: Option<PathBuf>,
+    pub tables_scan_max_depth: Option<usize>,
     pub diff: Option<String>,
     pub editor: Option<String>,
     pub launch_templates: Option<Vec<LaunchTemplate>>,
@@ -41,6 +42,7 @@ pub struct ResolvedConfig {
     pub vpx_config: PathBuf,
     pub tables_folder: PathBuf,
     pub tables_index_path: PathBuf,
+    pub tables_scan_max_depth: Option<usize>,
     pub diff: Option<String>,
     pub editor: Option<String>,
 }
@@ -169,6 +171,7 @@ fn read_config(config_path: &Path) -> io::Result<ResolvedConfig> {
         vpx_config,
         tables_folder: tables_folder.clone(),
         tables_index_path: tables_index_path(&tables_folder),
+        tables_scan_max_depth: config.tables_scan_max_depth,
         diff: config.diff,
         editor: config.editor,
     };
@@ -329,6 +332,7 @@ fn write_default_config(config_file: &Path, vpx_executable: &Path) -> io::Result
         launch_templates: Some(launch_templates),
         vpx_config: Some(vpx_config.clone()),
         tables_folder: Some(tables_folder.clone()),
+        tables_scan_max_depth: None,
         diff: None,
         editor: None,
     };
@@ -448,6 +452,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/home/me/tables"),
                 tables_index_path: PathBuf::from("/home/me/tables/vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
             }
@@ -498,6 +503,21 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_read_config_with_tables_scan_max_depth() -> io::Result<()> {
+        let temp_dir = testdir!();
+        let config_file = temp_dir.join(CONFIGURATION_FILE_NAME);
+        let mut file = File::create(&config_file)?;
+        file.write_all(
+            b"vpx_executable = \"/tmp/test/vpinball\"\n\
+              tables_scan_max_depth = 2\n",
+        )?;
+
+        let config = read_config(&config_file)?;
+        assert_eq!(config.tables_scan_max_depth, Some(2));
+        Ok(())
+    }
+
     // test that we can read an incomplete config file with missing tables_folder
     #[cfg(target_os = "linux")]
     #[test]
@@ -542,6 +562,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/tmp/test/tables"),
                 tables_index_path: PathBuf::from("/tmp/test/tables/vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
             }
@@ -593,6 +614,7 @@ mod tests {
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: expected_tables_dir.clone(),
                 tables_index_path: expected_tables_dir.join("vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
             }
@@ -617,6 +639,7 @@ mod tests {
                 vpx_config: PathBuf::from("C:\\test\\VPinballX.ini"),
                 tables_folder: PathBuf::from("C:\\test\\tables"),
                 tables_index_path: PathBuf::from("C:\\test\\tables\\vpxtool_index.json"),
+                tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
                 launch_templates: vec!(

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -118,6 +118,7 @@ impl TableOption {
 pub fn frontend_index(
     resolved_config: &ResolvedConfig,
     recursive: bool,
+    max_depth: Option<usize>,
     force_reindex: Vec<PathBuf>,
 ) -> Result<Vec<IndexedTable>, IndexError> {
     let pb = ProgressBar::hidden();
@@ -130,6 +131,7 @@ pub fn frontend_index(
     let progress = ProgressBarProgress::new(pb);
     let index = indexer::index_folder(
         recursive,
+        max_depth,
         &resolved_config.tables_folder,
         &resolved_config.tables_index_path,
         Some(&resolved_config.global_pinmame_folder()),
@@ -244,7 +246,12 @@ fn table_menu(
                 exit = true;
             }
             Some(TableOption::ForceReload) => {
-                match frontend_index(config, true, vec![selected_path.clone()]) {
+                match frontend_index(
+                    config,
+                    true,
+                    config.tables_scan_max_depth,
+                    vec![selected_path.clone()],
+                ) {
                     Ok(index) => {
                         vpx_files_with_tableinfo.clear();
                         vpx_files_with_tableinfo.extend(index);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -262,40 +262,49 @@ pub fn find_roms(rom_path: &Path) -> io::Result<HashMap<String, PathBuf>> {
     Ok(roms)
 }
 
-pub fn find_vpx_files(recursive: bool, tables_path: &Path) -> io::Result<Vec<PathWithMetadata>> {
+pub fn find_vpx_files(
+    recursive: bool,
+    max_depth: Option<usize>,
+    tables_path: &Path,
+) -> io::Result<Vec<PathWithMetadata>> {
     if recursive {
-        let mut vpx_files = Vec::new();
-        let mut entries = walk_dir_filtered(tables_path);
+        let mut vpx_paths = Vec::new();
+        let mut entries = walk_dir_filtered(tables_path, max_depth);
         entries.try_for_each(|entry| {
             let dir_entry = entry?;
-            let path = dir_entry.path();
-            if path.is_file()
-                && let Some("vpx") = path.extension().and_then(OsStr::to_str)
-            {
-                let last_modified = last_modified(path)?;
-                vpx_files.push(PathWithMetadata {
-                    path: path.to_path_buf(),
-                    last_modified,
-                });
+            if dir_entry.file_type().is_file() {
+                let path = dir_entry.path();
+                if let Some("vpx") = path.extension().and_then(OsStr::to_str) {
+                    vpx_paths.push(path.to_path_buf());
+                }
             }
             Ok::<(), io::Error>(())
         })?;
-        Ok(vpx_files)
+        vpx_paths
+            .par_iter()
+            .map(|path| {
+                let last_modified = last_modified(path)?;
+                Ok(PathWithMetadata {
+                    path: path.clone(),
+                    last_modified,
+                })
+            })
+            .collect()
     } else {
         let mut vpx_files = Vec::new();
         // TODO is there a cleaner version like try_filter_map?
         let mut dirs = fs::read_dir(tables_path)?;
         dirs.try_for_each(|entry| {
             let dir_entry = entry?;
-            let path = dir_entry.path();
-            if path.is_file()
-                && let Some("vpx") = path.extension().and_then(OsStr::to_str)
-            {
-                let last_modified = last_modified(&path)?;
-                vpx_files.push(PathWithMetadata {
-                    path: path.to_path_buf(),
-                    last_modified,
-                });
+            if dir_entry.file_type()?.is_file() {
+                let path = dir_entry.path();
+                if let Some("vpx") = path.extension().and_then(OsStr::to_str) {
+                    let last_modified = last_modified(&path)?;
+                    vpx_files.push(PathWithMetadata {
+                        path: path.to_path_buf(),
+                        last_modified,
+                    });
+                }
             }
             Ok::<(), io::Error>(())
         })?;
@@ -304,12 +313,19 @@ pub fn find_vpx_files(recursive: bool, tables_path: &Path) -> io::Result<Vec<Pat
 }
 
 /// Walks the directory and filters out .git and __MACOSX folders
-fn walk_dir_filtered(tables_path: &Path) -> FilterEntry<IntoIter, fn(&DirEntry) -> bool> {
-    WalkDir::new(tables_path).into_iter().filter_entry(|entry| {
-        let path = entry.path();
-        let git = std::path::Component::Normal(".git".as_ref());
-        let macosx = std::path::Component::Normal("__MACOSX".as_ref());
-        !path.components().any(|c| c == git) && !path.components().any(|c| c == macosx)
+fn walk_dir_filtered(
+    tables_path: &Path,
+    max_depth: Option<usize>,
+) -> FilterEntry<IntoIter, fn(&DirEntry) -> bool> {
+    let mut walkdir = WalkDir::new(tables_path);
+    if let Some(max_depth) = max_depth {
+        walkdir = walkdir.max_depth(max_depth);
+    }
+    walkdir.into_iter().filter_entry(|entry| {
+        if !entry.file_type().is_dir() {
+            return true;
+        }
+        !matches!(entry.file_name().to_str(), Some(".git" | "__MACOSX"))
     })
 }
 
@@ -365,8 +381,10 @@ impl From<io::Error> for IndexError {
 /// * `configured_pinmame_path`: the path to the local pinmame folder configured in the vpinball config.
 /// * `progress`: lister for progress updates.
 /// * `force_reindex`: a list of vpx files to reindex, even if they are not modified.
+#[allow(clippy::too_many_arguments)]
 pub fn index_folder(
     recursive: bool,
+    max_depth: Option<usize>,
     tables_folder: &Path,
     tables_index_path: &Path,
     global_pinmame_path: Option<&Path>,
@@ -390,7 +408,7 @@ pub fn index_folder(
     }
     let mut index = existing_index.unwrap_or(TablesIndex::empty());
 
-    let vpx_files = find_vpx_files(recursive, tables_folder)?;
+    let vpx_files = find_vpx_files(recursive, max_depth, tables_folder)?;
     info!("  Found {} tables", vpx_files.len());
     // remove files that are missing
     let removed_len = index.remove_missing(&vpx_files);
@@ -820,7 +838,7 @@ mod tests {
         // let output_str = String::from_utf8_lossy(&output.stdout);
         // println!("global_pinmame_dir:\n{}", output_str);
 
-        let vpx_files = find_vpx_files(true, &tables_dir)?;
+        let vpx_files = find_vpx_files(true, None, &tables_dir)?;
         assert_eq!(vpx_files.len(), 3);
         let global_roms = find_roms(&global_roms_dir)?;
         assert_eq!(global_roms.len(), 1);
@@ -869,7 +887,7 @@ mod tests {
         vpx::new_minimal_vpx(&vpx_a_path)?;
         vpx::new_minimal_vpx(&vpx_m_path)?;
 
-        let vpx_files = find_vpx_files(true, &tables_dir)?;
+        let vpx_files = find_vpx_files(true, None, &tables_dir)?;
         let indexed = index_vpx_files(vpx_files, None, None, &VoidProgress)?;
 
         let json: TablesIndexJson = indexed.into();


### PR DESCRIPTION
Adds an optional `tables_scan_max_depth` setting to `Config`/`ResolvedConfig` and a corresponding `--max-depth` CLI flag on both the `frontend` and `index` subcommands. Useful for large NAS shares where scanning the full directory tree is expensive.