### PR TITLE
fix(indexer): write index_json atomically via temp + rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2328,7 @@ dependencies = [
 name = "vpxtool"
 version = "0.27.2"
 dependencies = [
+ "atomicwrites",
  "base64",
  "chrono",
  "clap",
@@ -2594,6 +2606,15 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ env_logger = "0.11.10"
 figment = { version = "0.10", features = ["toml", "env"] }
 walkdir = "2.5.0"
 rayon = "1.12.0"
+atomicwrites = "0.4.4"
 
 [dev-dependencies]
 testdir = "0.9.3"

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,3 +1,4 @@
+use atomicwrites::{AllowOverwrite, AtomicFile};
 use chrono::{DateTime, Utc};
 use log::info;
 use rayon::prelude::*;
@@ -679,13 +680,18 @@ fn last_modified(path: &Path) -> io::Result<SystemTime> {
 }
 
 pub fn write_index_json(indexed_tables: &TablesIndex, json_path: &Path) -> io::Result<()> {
-    let json_file = File::create(json_path)?;
-    let mut writer = BufWriter::new(json_file);
+    // Write through a sibling temp file and atomically rename on success, so an
+    // interrupted run (Ctrl-C, crash, power loss) leaves the previous index intact
+    // instead of a half-written one. See issue #442.
     let indexed_tables_json: TablesIndexJson = indexed_tables.into();
-    serde_json::to_writer_pretty(&mut writer, &indexed_tables_json).map_err(io::Error::other)?;
-    // BufWriter flushes on drop but discards errors, so flush explicitly to surface
-    // late write failures (full disk, NAS drop) instead of silently truncating the index.
-    writer.flush()
+    AtomicFile::new(json_path, AllowOverwrite)
+        .write(|f| {
+            let mut writer = BufWriter::new(f);
+            serde_json::to_writer_pretty(&mut writer, &indexed_tables_json)
+                .map_err(io::Error::other)?;
+            writer.flush()
+        })
+        .map_err(io::Error::from)
 }
 
 pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {


### PR DESCRIPTION
## Summary
Use `atomic-write-file` to write `vpxtool_index.json` through a sibling temp file and atomically rename on commit. An interrupted run (Ctrl-C, crash, power loss) now leaves the previous index intact instead of a half-written one - the temp file is cleaned up on Drop and the rename only happens after a successful flush + fsync via `commit()`.

Closes #442.

## Notes
- This supersedes #737. The atomic-write approach inherently surfaces flush errors via `BufWriter::into_inner()` + `commit()`, so the explicit `flush()?` from #737 is no longer needed.
- `atomic-write-file` writes the temp file in the same directory as the target so the rename stays on the same filesystem (required for atomicity).

## Test plan
- [x] `cargo test --lib indexer::` -> all 29 tests pass
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`