### PR TITLE
fix(indexer): hand-roll atomic write to avoid parent-dir fsync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,17 +172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomicwrites"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
-dependencies = [
- "rustix 0.38.44",
- "tempfile",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,7 +2317,6 @@ dependencies = [
 name = "vpxtool"
 version = "0.28.0"
 dependencies = [
- "atomicwrites",
  "base64",
  "chrono",
  "clap",
@@ -2606,15 +2594,6 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ env_logger = "0.11.10"
 figment = { version = "0.10", features = ["toml", "env"] }
 walkdir = "2.5.0"
 rayon = "1.12.0"
-atomicwrites = "0.4.4"
 
 [dev-dependencies]
 testdir = "0.9.3"

--- a/src/atomicwrite.rs
+++ b/src/atomicwrite.rs
@@ -1,0 +1,69 @@
+use std::fs::{self, File};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Write `path` atomically: writes through a sibling `.tmp` file, fsyncs the
+/// content, renames on success, then fsyncs the parent directory. The `.tmp`
+/// is removed on any error path. An interrupted run (Ctrl-C, crash) leaves
+/// the previous file intact instead of a half-written one.
+///
+/// The parent-directory fsync makes the rename durable against power loss
+/// (without it, a crash in the brief window after rename returns could leave
+/// the old file under the target name). On filesystems that don't support
+/// directory fsync - notably macOS SMB/NFS mounts which return ENOTSUP -
+/// we treat it as a soft success, since the rename itself has already
+/// happened. This is the same trade-off the popular atomic-write crates
+/// make implicitly, except they propagate the unsupported-error and there's
+/// no opt-out:
+///   - atomicwrites: https://github.com/untitaker/rust-atomicwrites
+///     (issue #45 about making the dir fsync optional)
+///   - atomic-write-file: https://github.com/andreacorbellini/rust-atomic-write-file
+pub(crate) fn atomic_write<F>(path: &Path, write: F) -> io::Result<()>
+where
+    F: FnOnce(&mut File) -> io::Result<()>,
+{
+    let mut tmp_os = path.as_os_str().to_owned();
+    tmp_os.push(".tmp");
+    let tmp_path = PathBuf::from(tmp_os);
+    let result = (|| -> io::Result<()> {
+        let mut file = File::create(&tmp_path)?;
+        write(&mut file)?;
+        file.sync_all()?;
+        fs::rename(&tmp_path, path)?;
+        fsync_parent_best_effort(path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp_path);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn fsync_parent_best_effort(path: &Path) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    match File::open(parent).and_then(|f| f.sync_all()) {
+        Ok(()) => Ok(()),
+        Err(e) if is_dir_fsync_unsupported(&e) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(not(unix))]
+fn fsync_parent_best_effort(_path: &Path) -> io::Result<()> {
+    // Windows opens directories with a different API and NTFS journals
+    // metadata aggressively; skip parent fsync there.
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_dir_fsync_unsupported(e: &io::Error) -> bool {
+    if e.kind() == io::ErrorKind::Unsupported {
+        return true;
+    }
+    // macOS SMB/NFS returns ENOTSUP (errno 45), which Rust's ErrorKind
+    // doesn't classify as Unsupported.
+    cfg!(target_os = "macos") && e.raw_os_error() == Some(45)
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,4 +1,3 @@
-use atomicwrites::{AllowOverwrite, AtomicFile};
 use chrono::{DateTime, Utc};
 use log::info;
 use rayon::prelude::*;
@@ -7,7 +6,7 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::fs::Metadata;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read};
 use std::sync::LazyLock;
 use std::time::SystemTime;
 use std::{
@@ -22,6 +21,8 @@ use vpin::vpx::tableinfo::TableInfo;
 use walkdir::{DirEntry, FilterEntry, IntoIter, WalkDir};
 
 use vpx::gamedata::GameData;
+
+use crate::atomicwrite::atomic_write;
 
 pub const DEFAULT_INDEX_FILE_NAME: &str = "vpxtool_index.json";
 
@@ -698,18 +699,14 @@ fn last_modified(path: &Path) -> io::Result<SystemTime> {
 }
 
 pub fn write_index_json(indexed_tables: &TablesIndex, json_path: &Path) -> io::Result<()> {
-    // Write through a sibling temp file and atomically rename on success, so an
-    // interrupted run (Ctrl-C, crash, power loss) leaves the previous index intact
-    // instead of a half-written one. See issue #442.
     let indexed_tables_json: TablesIndexJson = indexed_tables.into();
-    AtomicFile::new(json_path, AllowOverwrite)
-        .write(|f| {
-            let mut writer = BufWriter::new(f);
-            serde_json::to_writer_pretty(&mut writer, &indexed_tables_json)
-                .map_err(io::Error::other)?;
-            writer.flush()
-        })
-        .map_err(io::Error::from)
+    atomic_write(json_path, |file| {
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, &indexed_tables_json)
+            .map_err(io::Error::other)?;
+        writer.into_inner().map_err(|e| e.into_error())?;
+        Ok(())
+    })
 }
 
 pub fn read_index_json(json_path: &Path) -> io::Result<Option<TablesIndex>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::fs::metadata;
 use std::io;
 use std::path::{Path, PathBuf};
 
+mod atomicwrite;
 mod backglass;
 pub mod fixprint;
 mod frontend;


### PR DESCRIPTION
## Summary
Replaces the `atomicwrites`-based implementation introduced in #739 with a hand-rolled sibling-temp + rename. Fixes the `IO error: Operation not supported (os error 45)` reported by @gitfool on macOS with a NAS-mounted index location.

## Why
`atomicwrites` does an unconditional `fsync` on the parent directory after the rename for extra durability. macOS SMB/NFS mounts return ENOTSUP for that operation, so the whole call fails even though the file is fully written and renamed correctly. `atomic-write-file` has the same unconditional parent-dir fsync, so swapping crates wouldn't help. There's an open upstream issue for atomicwrites (untitaker/rust-atomicwrites#45) about making it optional, but no PR yet.

The hand-rolled version syncs the file content (`File::sync_all()` before the rename) and then renames. It deliberately skips the parent-dir fsync. The trade-off:

- We still cannot leave a half-written index file on Ctrl-C / crash (the original goal of #442 / #739).
- We lose durability against a hard power loss in the narrow window after the rename returns but before the directory entry is on disk: in that case the user would see the *old* index, not the new one. Since the index is regenerable from the `.vpx` files this is acceptable.

A code comment in `write_index_json` explains the trade-off and links to both crates we evaluated.

## Notes
- Drops the `atomicwrites` dependency.
- Cleans up the `.tmp` sibling on any error path.

## Test plan
- [x] `cargo test --lib indexer::` -> all 30 tests pass
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] @gitfool to verify on macOS + NAS once landed