### PR TITLE
refactor(frontend): take configured_pinmame_folder as a parameter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -255,7 +255,11 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                     Ok(ExitCode::FAILURE)
                 }
                 Ok(vpx_files_with_tableinfo) => {
-                    frontend::frontend(&config, vpx_files_with_tableinfo);
+                    frontend::frontend(
+                        &config,
+                        configured_pinmame_folder.as_deref(),
+                        vpx_files_with_tableinfo,
+                    );
                     Ok(ExitCode::SUCCESS)
                 }
                 Err(IndexError::FolderDoesNotExist(path)) => {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -148,8 +148,11 @@ pub fn frontend_index(
     Ok(tables)
 }
 
-pub fn frontend(config: &ResolvedConfig, mut vpx_files_with_tableinfo: Vec<IndexedTable>) {
-    let configured_pinmame_folder = config.configured_pinmame_folder();
+pub fn frontend(
+    config: &ResolvedConfig,
+    configured_pinmame_folder: Option<&Path>,
+    mut vpx_files_with_tableinfo: Vec<IndexedTable>,
+) {
     let mut main_selection_opt = None;
     loop {
         let tables: Vec<String> = vpx_files_with_tableinfo
@@ -193,7 +196,7 @@ pub fn frontend(config: &ResolvedConfig, mut vpx_files_with_tableinfo: Vec<Index
                             let info_str = display_table_line_full(&info);
                             table_menu(
                                 config,
-                                configured_pinmame_folder.as_deref(),
+                                configured_pinmame_folder,
                                 &mut vpx_files_with_tableinfo,
                                 &info,
                                 &info_str,
@@ -222,7 +225,7 @@ pub fn frontend(config: &ResolvedConfig, mut vpx_files_with_tableinfo: Vec<Index
                             let info_str = display_table_line_full(info);
                             table_menu(
                                 config,
-                                configured_pinmame_folder.as_deref(),
+                                configured_pinmame_folder,
                                 &mut vpx_files_with_tableinfo,
                                 info,
                                 &info_str,
@@ -236,7 +239,7 @@ pub fn frontend(config: &ResolvedConfig, mut vpx_files_with_tableinfo: Vec<Index
                         let info_str = display_table_line_full(&info);
                         table_menu(
                             config,
-                            configured_pinmame_folder.as_deref(),
+                            configured_pinmame_folder,
                             &mut vpx_files_with_tableinfo,
                             &info,
                             &info_str,


### PR DESCRIPTION
## Summary
Follow-up to #733. Drops the remaining duplicate `configured_pinmame_folder()` call at the top of `frontend()` by threading the value resolved in `cli.rs` CMD_FRONTEND down into the menu loop.

After #733, the picture was:
- CMD_FRONTEND in `cli.rs` reads the ini once for the print + `frontend_index`.
- `frontend()` reads it AGAIN at the top of the menu loop.
- From there, the value is correctly threaded to `table_menu` -> `ForceReload` -> `frontend_index` (so per-press reload no longer re-reads).

This PR takes the resolved value from CMD_FRONTEND and passes it into `frontend()` as `Option<&Path>`, matching the same shape `frontend_index` already uses. Net: one ini read per `vpxtool frontend` invocation.

## Test plan
- [x] `cargo test --lib` -> all 55 tests pass
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`