### PR TITLE
perf: parallelize directory walk and reduce NAS round-trips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +573,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1191,6 +1222,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
 ]
 
 [[package]]
@@ -1857,15 +1898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "sanitize-filename"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2366,7 @@ dependencies = [
  "indicatif",
  "is_executable",
  "jojodiff",
+ "jwalk",
  "log",
  "pinmame-nvram",
  "pretty_assertions",
@@ -2346,18 +2379,7 @@ dependencies = [
  "testdir",
  "toml 1.1.2+spec-1.1.0",
  "vpin",
- "walkdir",
  "wild",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -2564,15 +2586,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 log = "0.4.29"
 env_logger = "0.11.10"
 figment = { version = "0.10", features = ["toml", "env"] }
-walkdir = "2.5.0"
+jwalk = "0.8.1"
 rayon = "1.12.0"
 
 [dev-dependencies]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use jwalk::WalkDir;
 use log::info;
 use rayon::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -17,7 +18,6 @@ use std::{
 use vpin::vpx;
 use vpin::vpx::jsonmodel::json_to_info;
 use vpin::vpx::tableinfo::TableInfo;
-use walkdir::{DirEntry, FilterEntry, IntoIter, WalkDir};
 
 use vpx::gamedata::GameData;
 
@@ -311,18 +311,68 @@ pub fn find_vpx_files(
     tables_path: &Path,
 ) -> io::Result<Vec<PathWithMetadata>> {
     if recursive {
+        // jwalk parallelises readdir calls across directories using rayon, so
+        // all subdirectory reads (e.g. one per manufacturer folder) happen
+        // concurrently rather than serially. Metadata is captured inline from
+        // the same readdir response, eliminating a separate stat pass.
+        let mut walk = WalkDir::new(tables_path).skip_hidden(false);
+        if let Some(depth) = max_depth {
+            walk = walk.max_depth(depth);
+        }
+        let results: Result<Vec<_>, _> = walk
+            .process_read_dir(|_, _, _, entries| {
+                // Drop .git and __MACOSX subdirectory entries before they are
+                // enqueued for parallel reads, avoiding wasted network RPCs.
+                entries.retain(|entry| match entry {
+                    Ok(e) if e.file_type().is_dir() => {
+                        !matches!(e.file_name().to_str(), Some(".git" | "__MACOSX"))
+                    }
+                    _ => true,
+                });
+            })
+            .into_iter()
+            .filter_map(|entry| {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(e) => return Some(Err(io::Error::from(e))),
+                };
+                if !entry.file_type().is_file() {
+                    return None;
+                }
+                if !matches!(
+                    entry.path().extension().and_then(OsStr::to_str),
+                    Some("vpx")
+                ) {
+                    return None;
+                }
+                // metadata() is cheap here: jwalk caches it from the readdir
+                // result (where the OS provides it) or fetches it in parallel.
+                let last_modified = match entry.metadata() {
+                    Ok(m) => match m.modified() {
+                        Ok(t) => t,
+                        Err(e) => return Some(Err(e)),
+                    },
+                    Err(e) => return Some(Err(io::Error::from(e))),
+                };
+                Some(Ok(PathWithMetadata {
+                    path: entry.path(),
+                    last_modified,
+                }))
+            })
+            .collect();
+        results
+    } else {
+        // Non-recursive: collect paths first, then fetch mtime in parallel.
         let mut vpx_paths = Vec::new();
-        let mut entries = walk_dir_filtered(tables_path, max_depth);
-        entries.try_for_each(|entry| {
+        for entry in fs::read_dir(tables_path)? {
             let dir_entry = entry?;
-            if dir_entry.file_type().is_file() {
+            if dir_entry.file_type()?.is_file() {
                 let path = dir_entry.path();
-                if let Some("vpx") = path.extension().and_then(OsStr::to_str) {
-                    vpx_paths.push(path.to_path_buf());
+                if matches!(path.extension().and_then(OsStr::to_str), Some("vpx")) {
+                    vpx_paths.push(path);
                 }
             }
-            Ok::<(), io::Error>(())
-        })?;
+        }
         vpx_paths
             .par_iter()
             .map(|path| {
@@ -333,43 +383,7 @@ pub fn find_vpx_files(
                 })
             })
             .collect()
-    } else {
-        let mut vpx_files = Vec::new();
-        // TODO is there a cleaner version like try_filter_map?
-        let mut dirs = fs::read_dir(tables_path)?;
-        dirs.try_for_each(|entry| {
-            let dir_entry = entry?;
-            if dir_entry.file_type()?.is_file() {
-                let path = dir_entry.path();
-                if let Some("vpx") = path.extension().and_then(OsStr::to_str) {
-                    let last_modified = last_modified(&path)?;
-                    vpx_files.push(PathWithMetadata {
-                        path: path.to_path_buf(),
-                        last_modified,
-                    });
-                }
-            }
-            Ok::<(), io::Error>(())
-        })?;
-        Ok(vpx_files)
     }
-}
-
-/// Walks the directory and filters out .git and __MACOSX folders
-fn walk_dir_filtered(
-    tables_path: &Path,
-    max_depth: Option<usize>,
-) -> FilterEntry<IntoIter, fn(&DirEntry) -> bool> {
-    let mut walkdir = WalkDir::new(tables_path);
-    if let Some(max_depth) = max_depth {
-        walkdir = walkdir.max_depth(max_depth);
-    }
-    walkdir.into_iter().filter_entry(|entry| {
-        if !entry.file_type().is_dir() {
-            return true;
-        }
-        !matches!(entry.file_name().to_str(), Some(".git" | "__MACOSX"))
-    })
 }
 
 pub trait Progress {
@@ -457,16 +471,16 @@ pub fn index_folder(
     let removed_len = index.remove_missing(&vpx_files);
     info!("  {removed_len} missing tables have been removed");
 
-    let tables_with_missing_rom = index
+    let tables_with_missing_rom: HashSet<PathBuf> = index
         .tables()
-        .iter()
+        .par_iter()
         .filter_map(|table| {
             table
                 .rom_path()
                 .filter(|rom_path| !rom_path.exists())
                 .map(|_| table.path.clone())
         })
-        .collect::<HashSet<PathBuf>>();
+        .collect();
     info!(
         "  {} tables will be re-indexed because their rom is missing",
         tables_with_missing_rom.len()
@@ -483,6 +497,10 @@ pub fn index_folder(
         }
     }
 
+    // The index is dirty if files were removed or any files need (re)indexing.
+    // When clean, we skip the write to avoid an unnecessary NAS round-trip.
+    let index_dirty = removed_len > 0 || !vpx_files_to_index.is_empty();
+
     info!("  {} tables need (re)indexing.", vpx_files_to_index.len());
     let vpx_files_with_table_info = index_vpx_files(
         vpx_files_to_index,
@@ -494,8 +512,10 @@ pub fn index_folder(
     // add new files to index
     index.merge(vpx_files_with_table_info);
 
-    // write the index to a file
-    write_index_json(&index, tables_index_path, Some(tables_folder))?;
+    if index_dirty {
+        // write the index to a file
+        write_index_json(&index, tables_index_path, Some(tables_folder))?;
+    }
 
     Ok(index)
 }


### PR DESCRIPTION
## Summary

I noticed when running `vpxtool frontend`, on macos with tables on nas, the "time to ui" perf varied wildly across repeated back-to-back runs. Further investigation quickly identified the remaining causes of delay in this scenario, which is not focused on full index rebuild like before, but time to ui when nothing has really changed.

Fixes highly variable startup time (2–28 s) when VPX table files are stored on a NAS (SMB/NFS), where each `readdir` and `stat` call is a network RPC with cache-TTL-driven latency.

## Root causes identified

1. **Serial directory walk** — `walkdir` reads one directory at a time. With N table subdirectories, that's N sequential `readdir` RPCs before the first table is returned.
2. **Unconditional index write** — `write_index_json` was called even when nothing changed, causing an unnecessary round-trip on every startup.
3. **Serial ROM existence checks** — `check_missing_roms` iterated tables with `.iter()`, issuing one `exists()` stat call per table sequentially.

## Changes

- **Replace `walkdir` with `jwalk`** — jwalk uses rayon internally to issue `readdir` calls for all subdirectories concurrently. Also captures mtime inline from the same kernel response, eliminating a separate stat pass per file.
- **Filter `.git`/`__MACOSX` eagerly** — done in `process_read_dir` before subdirectories are enqueued, avoiding wasted network RPCs on those paths.
- **`index_dirty` guard** — `write_index_json` is now skipped when no files were added, removed, or modified, saving the NAS fsync on every clean startup.
- **Parallelize ROM existence checks** — changed `.iter()` to `.par_iter()` so all `rom_path.exists()` calls issue concurrently.

## Results

Time to ui is now much more consistent/stable and takes at most a few seconds.