### PR TITLE
fix: drop deprecated -*TrueFullscreen flags from defaults (#730)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ vpx_executable = "/home/myuser/vpinball/VPinballX_BGFX"
 
 # Optional settings below, only needed if the defaults don't work
 tables_folder = "/home/myuser/vpinball/tables"
-vpx_config = "/home/myuser/.vpinball/VPinballX.ini"
+vpx_config = "/home/myuser/.local/share/VPinballX/10.8/VPinballX.ini"
 ```
 
 Further settings will be picked up from the Visual Pinball config.
@@ -159,11 +159,16 @@ Further settings will be picked up from the Visual Pinball config.
 Sometimes you want to use a different executables, extra arguments or environment variables. This can be done
 by setting up launch templates. Each entry will show up on top of the frontend table menu.
 
+To force fullscreen or windowed mode, point a template at a separate vpinball ini file (passed to vpinball as
+`-Ini <path>`) with the relevant `FullScreen` / `PlayfieldFullScreen` keys overridden. The previous
+`-EnableTrueFullscreen` / `-DisableTrueFullscreen` CLI flags are deprecated upstream and not present in
+modern (BGFX) vpinball builds.
+
 ```toml
 [[launch_templates]]
 name = "Launch fullscreen"
 executable = "/home/myuser/vpinball/VPinballX_BGFX"
-arguments = ["-EnableTrueFullscreen"]
+vpinball_config = "/home/myuser/.local/share/VPinballX/10.8/VPinballX.fullscreen.ini"
 
 [[launch_templates]]
 name = "Launch GL"

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,34 +179,24 @@ fn read_config(config_path: &Path) -> io::Result<ResolvedConfig> {
 }
 
 fn generate_default_launch_templates(vpx_executable: &Path) -> Vec<LaunchTemplate> {
+    // Only the basic Launch template is shipped by default. The previous
+    // "Launch Fullscreen"/"Launch Windowed" templates relied on
+    // -EnableTrueFullscreen/-DisableTrueFullscreen, which are deprecated and
+    // not compiled into modern (BGFX) vpinball builds. Users who want forced
+    // modes can define extra templates pointing at their own ini variants
+    // via vpinball_config (passed to vpinball as -Ini <path>).
     let default_env = HashMap::from([
         ("SDL_VIDEODRIVER".to_string(), "".to_string()),
         ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
     ]);
 
-    vec![
-        LaunchTemplate {
-            name: "Launch".to_string(),
-            executable: vpx_executable.to_owned(),
-            arguments: None,
-            env: Some(default_env.clone()),
-            vpinball_config: None,
-        },
-        LaunchTemplate {
-            name: "Launch Fullscreen".to_string(),
-            executable: vpx_executable.to_owned(),
-            arguments: Some(vec!["-EnableTrueFullscreen".to_string()]),
-            env: None,
-            vpinball_config: None,
-        },
-        LaunchTemplate {
-            name: "Launch Windowed".to_string(),
-            executable: vpx_executable.to_owned(),
-            arguments: Some(vec!["-DisableTrueFullscreen".to_string()]),
-            env: None,
-            vpinball_config: None,
-        },
-    ]
+    vec![LaunchTemplate {
+        name: "Launch".to_string(),
+        executable: vpx_executable.to_owned(),
+        arguments: None,
+        env: Some(default_env),
+        vpinball_config: None,
+    }]
 }
 
 pub fn tables_index_path(tables_folder: &Path) -> PathBuf {
@@ -422,32 +412,16 @@ mod tests {
             config,
             ResolvedConfig {
                 vpx_executable: PathBuf::from("/home/me/vpinball"),
-                launch_templates: vec!(
-                    LaunchTemplate {
-                        name: "Launch".to_string(),
-                        executable: PathBuf::from("/home/me/vpinball"),
-                        arguments: None,
-                        env: Some(HashMap::from([
-                            ("SDL_VIDEODRIVER".to_string(), "".to_string()),
-                            ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
-                        ])),
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Fullscreen".to_string(),
-                        executable: PathBuf::from("/home/me/vpinball"),
-                        arguments: Some(vec!["-EnableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Windowed".to_string(),
-                        executable: PathBuf::from("/home/me/vpinball"),
-                        arguments: Some(vec!["-DisableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    },
-                ),
+                launch_templates: vec!(LaunchTemplate {
+                    name: "Launch".to_string(),
+                    executable: PathBuf::from("/home/me/vpinball"),
+                    arguments: None,
+                    env: Some(HashMap::from([
+                        ("SDL_VIDEODRIVER".to_string(), "".to_string()),
+                        ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
+                    ])),
+                    vpinball_config: None,
+                },),
 
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/home/me/tables"),
@@ -533,32 +507,16 @@ mod tests {
             config,
             ResolvedConfig {
                 vpx_executable: PathBuf::from("/tmp/test/vpinball"),
-                launch_templates: vec!(
-                    LaunchTemplate {
-                        name: "Launch".to_string(),
-                        executable: PathBuf::from("/tmp/test/vpinball"),
-                        arguments: None,
-                        env: Some(HashMap::from([
-                            ("SDL_VIDEODRIVER".to_string(), "".to_string()),
-                            ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
-                        ])),
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Fullscreen".to_string(),
-                        executable: PathBuf::from("/tmp/test/vpinball"),
-                        arguments: Some(vec!["-EnableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Windowed".to_string(),
-                        executable: PathBuf::from("/tmp/test/vpinball"),
-                        arguments: Some(vec!["-DisableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    },
-                ),
+                launch_templates: vec!(LaunchTemplate {
+                    name: "Launch".to_string(),
+                    executable: PathBuf::from("/tmp/test/vpinball"),
+                    arguments: None,
+                    env: Some(HashMap::from([
+                        ("SDL_VIDEODRIVER".to_string(), "".to_string()),
+                        ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
+                    ])),
+                    vpinball_config: None,
+                },),
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: PathBuf::from("/tmp/test/tables"),
                 tables_index_path: PathBuf::from("/tmp/test/tables/vpxtool_index.json"),
@@ -585,32 +543,16 @@ mod tests {
             config,
             ResolvedConfig {
                 vpx_executable: PathBuf::from("/tmp/test/vpinball"),
-                launch_templates: vec!(
-                    LaunchTemplate {
-                        name: "Launch".to_string(),
-                        executable: PathBuf::from("/tmp/test/vpinball"),
-                        arguments: None,
-                        env: Some(HashMap::from([
-                            ("SDL_VIDEODRIVER".to_string(), "".to_string()),
-                            ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
-                        ])),
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Fullscreen".to_string(),
-                        executable: PathBuf::from("/tmp/test/vpinball"),
-                        arguments: Some(vec!["-EnableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Windowed".to_string(),
-                        executable: PathBuf::from("/tmp/test/vpinball"),
-                        arguments: Some(vec!["-DisableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    }
-                ),
+                launch_templates: vec!(LaunchTemplate {
+                    name: "Launch".to_string(),
+                    executable: PathBuf::from("/tmp/test/vpinball"),
+                    arguments: None,
+                    env: Some(HashMap::from([
+                        ("SDL_VIDEODRIVER".to_string(), "".to_string()),
+                        ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
+                    ])),
+                    vpinball_config: None,
+                }),
                 vpx_config: dirs::home_dir().unwrap().join(".vpinball/VPinballX.ini"),
                 tables_folder: expected_tables_dir.clone(),
                 tables_index_path: expected_tables_dir.join("vpxtool_index.json"),
@@ -642,32 +584,16 @@ mod tests {
                 tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
-                launch_templates: vec!(
-                    LaunchTemplate {
-                        name: "Launch".to_string(),
-                        executable: PathBuf::from("C:\\test\\vpinball"),
-                        arguments: None,
-                        env: Some(HashMap::from([
-                            ("SDL_VIDEODRIVER".to_string(), "".to_string()),
-                            ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
-                        ])),
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Fullscreen".to_string(),
-                        executable: PathBuf::from("C:\\test\\vpinball"),
-                        arguments: Some(vec!["-EnableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    },
-                    LaunchTemplate {
-                        name: "Launch Windowed".to_string(),
-                        executable: PathBuf::from("C:\\test\\vpinball"),
-                        arguments: Some(vec!["-DisableTrueFullscreen".to_string()]),
-                        env: None,
-                        vpinball_config: None,
-                    }
-                )
+                launch_templates: vec!(LaunchTemplate {
+                    name: "Launch".to_string(),
+                    executable: PathBuf::from("C:\\test\\vpinball"),
+                    arguments: None,
+                    env: Some(HashMap::from([
+                        ("SDL_VIDEODRIVER".to_string(), "".to_string()),
+                        ("SDL_RENDER_DRIVER".to_string(), "".to_string()),
+                    ])),
+                    vpinball_config: None,
+                })
             }
         );
         Ok(())


### PR DESCRIPTION
The default launch templates included "Launch Fullscreen" and "Launch Windowed" which passed -EnableTrueFullscreen / -DisableTrueFullscreen to vpinball. These flags are deprecated upstream and not compiled into modern (BGFX) builds, so users on a current vpinball get "Invalid Parameter" out of the box.

- generate_default_launch_templates now ships only the base "Launch" template; the table menu naturally collapses to a single launch entry.
- README documents the modern way to force fullscreen/windowed: a separate vpinball ini pointed at via vpinball_config (-Ini <path>).

closes #730 