### PR TITLE
feat(cli): add lock / unlock / lock-status commands (#317)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,9 +2326,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.23.6"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c47b38c7e495847efe456e1c8320db9de912695eba2e7dfbafa67f5182d3fc"
+checksum = "f6113bf2f3a8aa6bcd400759ae66c18c1073e96726402f4356dfcaf66e20ff10"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.23.6" }
+vpin = { version = "0.24.0" }
 directb2s = "0.1.1"
 
 edit = "0.1.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,15 @@ const CMD_IMPORT_VBS: &str = "importvbs";
 const CMD_PATCH: &str = "patch";
 const CMD_VERIFY: &str = "verify";
 const CMD_NEW: &str = "new";
+const CMD_LOCK: &str = "lock";
+const CMD_UNLOCK: &str = "unlock";
+const CMD_LOCK_STATUS: &str = "lock-status";
+
+enum LockAction {
+    Lock,
+    Unlock,
+    Status,
+}
 
 const CMD_LS: &str = "ls";
 
@@ -572,6 +581,10 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             }
             Ok(ExitCode::SUCCESS)
         }
+
+        Some((CMD_LOCK, sub_matches)) => run_lock(sub_matches, LockAction::Lock),
+        Some((CMD_UNLOCK, sub_matches)) => run_lock(sub_matches, LockAction::Unlock),
+        Some((CMD_LOCK_STATUS, sub_matches)) => run_lock(sub_matches, LockAction::Status),
         Some((CMD_NEW, sub_matches)) => {
             let path = {
                 let this = sub_matches.get_one::<String>("VPXPATH").map(|v| v.as_str());
@@ -1011,6 +1024,21 @@ fn build_command() -> Command {
                         .required(true)
                         .num_args(1..),
                 ),
+        )
+        .subcommand(
+            Command::new(CMD_LOCK)
+                .about("Lock a vpx file, preventing edits in vpinball")
+                .arg(arg!(<VPXPATH> "The path to the vpx file").required(true)),
+        )
+        .subcommand(
+            Command::new(CMD_UNLOCK)
+                .about("Unlock a vpx file")
+                .arg(arg!(<VPXPATH> "The path to the vpx file").required(true)),
+        )
+        .subcommand(
+            Command::new(CMD_LOCK_STATUS)
+                .about("Show the lock state of a vpx file")
+                .arg(arg!(<VPXPATH> "The path to the vpx file").required(true)),
         )
         .subcommand(
             Command::new(CMD_ASSEMBLE)
@@ -1690,4 +1718,44 @@ fn show_dip_switches(nvram: &PathBuf) -> io::Result<String> {
 
     let summary = lines.join("\n");
     Ok(summary)
+}
+
+fn run_lock(sub_matches: &ArgMatches, action: LockAction) -> io::Result<ExitCode> {
+    let path = sub_matches
+        .get_one::<String>("VPXPATH")
+        .expect("VPXPATH is required");
+    let expanded = path_exists(path)?;
+    apply_lock_action(&expanded, &action)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
+    match action {
+        LockAction::Status => {
+            let mut vpx = vpx::open(path)?;
+            let state = if vpx.is_locked()? {
+                "locked"
+            } else {
+                "unlocked"
+            };
+            crate::println!("{}: {}", path.display(), state)?;
+        }
+        LockAction::Lock => {
+            let mut vpx = vpx::open_rw(path)?;
+            if vpx.lock()? {
+                crate::println!("Locked {}", path.display())?;
+            } else {
+                crate::println!("Already locked: {}", path.display())?;
+            }
+        }
+        LockAction::Unlock => {
+            let mut vpx = vpx::open_rw(path)?;
+            if vpx.unlock()? {
+                crate::println!("Unlocked {}", path.display())?;
+            } else {
+                crate::println!("Already unlocked: {}", path.display())?;
+            }
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
Top-level subcommands for managing the vpinball table-lock state on a single vpx file. lock and unlock are idempotent (no-op if already in the requested state) with output that distinguishes "actually wrote" from "no change needed". lock-status reports a plain "locked" / "unlocked" without exposing the internal counter.

  vpxtool lock <vpx>          # ensure locked, prints
                              #   "Locked <path>" or "Already locked: <path>"
  vpxtool unlock <vpx>        # symmetric
  vpxtool lock-status <vpx>   # prints "<path>: locked" or "<path>: unlocked"

Wraps VpxFile::lock / unlock / is_locked from vpin 0.24.0, which rewrites only the GameData stream + MAC rather than re-serialising the entire file. Smoke tested locally with `vpxtool new` -> lock/unlock cycles -> `vpxtool verify` (file integrity preserved).

Bumps the vpin dependency from 0.23.6 to 0.24.0.

closes #317 