### PR TITLE
fix(config): preserve comments and layout in rewrite_vpx_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2183,6 +2183,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -2201,6 +2210,19 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
  "winnow 0.7.13",
 ]
 
@@ -2383,6 +2405,7 @@ dependencies = [
  "serde_json",
  "testdir",
  "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.23.10+spec-1.0.0",
  "vpin",
  "wild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 rust-ini = "0.21.3"
 dirs = "6.0.0"
 toml = "1.1.2"
+toml_edit = "0.23"
 serde = { version = "1.0.228", features = ["derive"] }
 log = "0.4.29"
 env_logger = "0.11.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,13 +295,13 @@ pub fn stale_vpx_config_suggestion(saved: &Path, vpx_executable: &Path) -> Optio
 }
 
 /// Rewrite the saved vpxtool config with `vpx_config` set to the given path.
-/// All other fields are preserved from the on-disk file. Comments and
-/// formatting are not preserved (toml round-trips through serde).
+/// All other fields are preserved from the on-disk file, along with comments,
+/// blank lines, and field ordering (uses `toml_edit` for in-place edits).
 pub fn rewrite_vpx_config(config_file: &Path, vpx_config: &Path) -> io::Result<()> {
     let toml_str = std::fs::read_to_string(config_file)?;
-    let mut config: Config = toml::from_str(&toml_str).map_err(io::Error::other)?;
-    config.vpx_config = Some(vpx_config.to_path_buf());
-    write_config(config_file, &config)
+    let mut doc: toml_edit::DocumentMut = toml_str.parse().map_err(io::Error::other)?;
+    doc["vpx_config"] = toml_edit::value(vpx_config.to_string_lossy().into_owned());
+    std::fs::write(config_file, doc.to_string())
 }
 
 fn legacy_vpinball_ini(vpx_executable_path: &Path) -> PathBuf {
@@ -704,5 +704,37 @@ mod tests {
     fn test_newest_versioned_vpinball_ini_returns_none_when_empty() {
         let base = testdir!().join("does-not-exist");
         assert_eq!(newest_versioned_vpinball_ini(&base), None);
+    }
+
+    #[test]
+    fn test_rewrite_vpx_config_preserves_comments_and_layout() -> io::Result<()> {
+        // A user-edited config file: comments, blank lines, and a non-default
+        // field ordering. After rewrite_vpx_config swaps the vpx_config value,
+        // everything else must come through byte-faithfully.
+        let temp_dir = testdir!();
+        let config_file = temp_dir.join(CONFIGURATION_FILE_NAME);
+        let original = "\
+# vpxtool config for the tournament rig
+
+vpx_executable = \"/home/me/vpinball\"
+
+# old default - vpxtool will offer to fix this
+vpx_config = \"/home/me/.vpinball/VPinballX.ini\"
+
+# don't recurse beyond two levels
+tables_scan_max_depth = 2
+";
+        std::fs::write(&config_file, original)?;
+
+        let new_path = PathBuf::from("/home/me/.local/share/VPinballX/10.8/VPinballX.ini");
+        rewrite_vpx_config(&config_file, &new_path)?;
+
+        let after = std::fs::read_to_string(&config_file)?;
+        let expected = original.replace(
+            "/home/me/.vpinball/VPinballX.ini",
+            "/home/me/.local/share/VPinballX/10.8/VPinballX.ini",
+        );
+        assert_eq!(after, expected);
+        Ok(())
     }
 }


### PR DESCRIPTION
The auto-correct path (added in #757 to migrate stale legacy vpx_config paths after a vpinball upgrade) round-tripped the file through serde via toml::from_str -> write_config, which discards comments, blank lines, and field ordering. A user who hand-edited their vpxtool.cfg would silently lose that on accept.

Switch to toml_edit::DocumentMut for an in-place edit of just the vpx_config value, leaving everything else byte-identical. toml_edit was already in the dep graph transitively (figment -> toml -> toml_edit); declared explicitly now.

Test feeds a config with comments, a blank line, and tables_scan_max_depth through rewrite_vpx_config and asserts the output is byte-equal to the input modulo the swapped value.