### PR TITLE
frontend: restore table position after launch and clear screen on normal exit

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -189,6 +189,8 @@ pub fn frontend(
                             .unwrap();
 
                         if let Some(selected_index) = selected {
+                            // return to the main list with the table selected
+                            main_selection_opt = Some(selected_index + 2);
                             let info = vpx_files_with_tableinfo
                                 .get(selected_index)
                                 .unwrap()
@@ -204,7 +206,7 @@ pub fn frontend(
                         }
                     }
                     RECENT_INDEX => {
-                        // take the last 10 most recent tables
+                        // take the last 50 most recently modified tables
                         let mut recent: Vec<IndexedTable> = vpx_files_with_tableinfo.clone();
                         recent.sort_by_key(|indexed| indexed.last_modified);
                         let last_modified = recent.iter().rev().take(50).collect::<Vec<_>>();
@@ -213,23 +215,29 @@ pub fn frontend(
                             .map(|indexed| display_table_line_full(indexed))
                             .collect();
 
-                        let selected = Select::with_theme(&ColorfulTheme::default())
-                            .with_prompt("Select a table")
-                            .items(&last_modified_str)
-                            .default(0)
-                            .interact_opt()
-                            .unwrap();
+                        let mut recent_selection: Option<usize> = None;
+                        loop {
+                            let selected = Select::with_theme(&ColorfulTheme::default())
+                                .with_prompt("Select a table")
+                                .items(&last_modified_str)
+                                .default(recent_selection.unwrap_or(0))
+                                .interact_opt()
+                                .unwrap();
 
-                        if let Some(selected_index) = selected {
-                            let info = last_modified.get(selected_index).unwrap();
-                            let info_str = display_table_line_full(info);
-                            table_menu(
-                                config,
-                                configured_pinmame_folder,
-                                &mut vpx_files_with_tableinfo,
-                                info,
-                                &info_str,
-                            );
+                            if let Some(selected_index) = selected {
+                                recent_selection = Some(selected_index);
+                                let info = last_modified.get(selected_index).unwrap();
+                                let info_str = display_table_line_full(info);
+                                table_menu(
+                                    config,
+                                    configured_pinmame_folder,
+                                    &mut vpx_files_with_tableinfo,
+                                    info,
+                                    &info_str,
+                                );
+                            } else {
+                                break;
+                            }
                         }
                     }
                     _ => {
@@ -827,7 +835,7 @@ fn launch(selected_path: &PathBuf, launch_template: &LaunchTemplate) {
     match launch_table(selected_path, launch_template) {
         Ok(status) => match status.code() {
             Some(0) => {
-                //println!("Table exited normally");
+                Term::stderr().clear_screen().ok();
             }
             Some(11) => {
                 prompt(&format!(


### PR DESCRIPTION
## Summary

Fixes the bug where returning to the frontend after quitting a VPX game would not restore the previously selected table position, instead landing on the Search option at the top of the list.

Also preserves table position when going into and then back out of a table menu, without launching a table, from the recent menu only. Since dialoguer does not expose the typed search text, restoring position within the same search list (with previous filter text) in this case is not possible.

## Changes

- **Search**: After selecting and launching a table via Search, return to the main list with that table selected (`selected_index + 2`). Note: dialoguer does not expose the typed search text, so restoring position within the search list (as done for Recent) is not possible.
- **Recent**: After launching a table via Recent, re-show the Recent list with the previously selected table as the default (inner loop with `recent_selection`).
- **Screen clear**: Clear the terminal screen after a normal (exit code 0) VPX exit, so VPX log output does not push the UI down on return.