### PR TITLE
chore(deps)!: bump vpin to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -2348,9 +2348,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6113bf2f3a8aa6bcd400759ae66c18c1073e96726402f4356dfcaf66e20ff10"
+checksum = "2d850d6617110e392e62f224473da0ab06ecd6f51eac1f52218f96822799eb83"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2369,6 +2369,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "wavefront-obj-io",
  "weezl",
 ]
 
@@ -2539,6 +2540,15 @@ dependencies = [
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wavefront-obj-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac7f033c82919052c8caa9af2e36708768dc32f692e96c9d5dfd317c58a643a"
+dependencies = [
+ "itoa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.24.0" }
+vpin = { version = "0.26.0" }
 directb2s = "0.1.1"
 
 edit = "0.1.5"


### PR DESCRIPTION
vpin 0.25 reworked OBJ output to match vpinball's File -> Export -> OBJ Mesh format, so `vpxtool extract` now emits OBJ files in that format instead of the previous Blender-style layout. The expanded extract layout has no compatibility guarantee between vpxtool versions, but flagging this release as breaking since byte-level extract output differs.

Other vpin 0.25/0.26 breaking changes (Primitive AABB typed as Vertex3D, new fields on ObjExportOptions/GltfExportOptions) do not touch any existing vpxtool usage.