### PR TITLE
feat(cli): add export vpxz subcommand for mobile transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,9 +310,9 @@ checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -535,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -955,6 +965,19 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "half"
@@ -2279,6 +2302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2419,7 @@ dependencies = [
  "figment",
  "fuzzy-matcher",
  "git-version",
+ "globset",
  "image",
  "indicatif",
  "is_executable",
@@ -2409,6 +2439,7 @@ dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
  "vpin",
  "wild",
+ "zip",
 ]
 
 [[package]]
@@ -2952,6 +2983,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3007,18 @@ name = "zmij"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ env_logger = "0.11.10"
 figment = { version = "0.10", features = ["toml", "env"] }
 jwalk = "0.8.1"
 rayon = "1.12.0"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
+globset = "0.4.18"
 
 [dev-dependencies]
 testdir = "0.9.3"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
   images          Vpx image related commands
   gamedata        Vpx gamedata related commands
   romname         Prints the PinMAME ROM name from a vpx file
-  export          Export a vpx table to a 3D model format (obj or gltf/glb)
+  export          Export a vpx table to obj/gltf/glb or to a vpxz mobile archive
   help            Print this message or the help of the given subcommand(s)
 
 Options:
@@ -197,6 +197,35 @@ want to override this with a specific editor, optionally specifying the path, yo
 # use Visual Studio Code as default editor
 editor = "code"
 ```
+
+### Excluding files from `export vpxz`
+
+`vpxtool export vpxz` bundles the chosen vpx and its parent-folder contents into a `.vpxz` archive for the Visual Pinball mobile app. A few classes of files are dropped automatically:
+
+* other `.vpx` files in the tree (the mobile importer rejects archives with more than one vpx) and their stem-keyed sidecars,
+* `.directb2s` files whose stem doesn't match the chosen vpx,
+* previously generated `.vpxz` archives.
+
+Anything else is included by default. To skip additional patterns, set `vpxz_excludes` in the config file. Patterns are gitignore-ish globs matched against paths relative to the vpx's parent folder; a trailing `/` matches the directory both at the top level and nested anywhere:
+
+```toml
+vpxz_excludes = [
+    "Downloads/",          # the table author's original archive / install docs
+    "downloads/",
+    "cache/",              # VPX runtime cache, regenerated on the device
+    "**/Thumbs.db",        # Windows folder thumbnails
+    "**/.DS_Store",        # macOS folder metadata
+    "**/*.bak",            # editor / VPX backups
+    "**/*~",               # Emacs-style backups
+
+    # Add your own. Examples:
+    # "user/",             # also drop desktop save state (high scores, options)
+    # "**/*.pov",          # camera POV files (desktop only)
+    # "**/*.res",          # legacy B2S Server resolution files (desktop only)
+]
+```
+
+The list above is the built-in default; if you don't set `vpxz_excludes`, that's what gets applied. Setting it replaces the default in full, so copy the entries you still want.
 
 ## Projects using vpxtool
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,7 @@ const CMD_ROMNAME: &str = "romname";
 const CMD_EXPORT: &str = "export";
 const CMD_EXPORT_OBJ: &str = "obj";
 const CMD_EXPORT_GLTF: &str = "gltf";
+const CMD_EXPORT_VPXZ: &str = "vpxz";
 
 const CMD_INDEX: &str = "index";
 const ARG_VERBOSE: &str = "VERBOSE";
@@ -745,6 +746,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
         Some((CMD_EXPORT, sub_matches)) => match sub_matches.subcommand() {
             Some((CMD_EXPORT_OBJ, sub_matches)) => handle_export_obj(sub_matches),
             Some((CMD_EXPORT_GLTF, sub_matches)) => handle_export_gltf(sub_matches),
+            Some((CMD_EXPORT_VPXZ, sub_matches)) => handle_export_vpxz(sub_matches),
             _ => unreachable!(),
         },
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachable!()
@@ -1178,6 +1180,32 @@ fn build_command() -> Command {
                         ),
                 )
                 .subcommand(
+                    Command::new(CMD_EXPORT_VPXZ)
+                        .about("Export the table as a .vpxz archive for the Visual Pinball mobile app")
+                        .long_about("Bundles the vpx and its sidecar files (.vbs, .ini, .directb2s, .png/.jpg) into a single .vpxz archive (a renamed zip). When the table is PinMAME-based, also bundles the matching rom zip from the configured pinmame folder unless --no-rom is set.")
+                        .arg(arg!(<VPXPATH> "The path to the vpx file").required(true))
+                        .arg(
+                            Arg::new("OUTPUT")
+                                .short('o')
+                                .long("output")
+                                .num_args(1)
+                                .help("Output .vpxz path. Defaults to <stem>.vpxz one folder up from the vpx, so re-runs don't recursively pick up the previous output."),
+                        )
+                        .arg(
+                            Arg::new("NO_ROM")
+                                .long("no-rom")
+                                .num_args(0)
+                                .help("Do not bundle the matching PinMAME rom zip"),
+                        )
+                        .arg(
+                            Arg::new("FORCE")
+                                .short('f')
+                                .long("force")
+                                .num_args(0)
+                                .help("Overwrite the output file if it already exists"),
+                        ),
+                )
+                .subcommand(
                     Command::new(CMD_EXPORT_GLTF)
                         .about("Export the table as a glTF or GLB file")
                         .arg(arg!(<VPXPATH> "The path to the vpx file").required(true))
@@ -1351,6 +1379,107 @@ fn handle_export_gltf(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     )?;
     export_gltf(&vpx, &output_path, &RealFileSystem, &options)?;
     crate::println!("Done.")?;
+    Ok(ExitCode::SUCCESS)
+}
+
+fn handle_export_vpxz(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
+    let path = sub_matches
+        .get_one::<String>("VPXPATH")
+        .map(|s| s.as_str())
+        .unwrap_or_default();
+    let expanded_path = path_exists(path)?;
+    let bundle_rom = !sub_matches.get_flag("NO_ROM");
+    let force = sub_matches.get_flag("FORCE");
+    let output = sub_matches.get_one::<String>("OUTPUT").map(PathBuf::from);
+
+    let output_path = match output {
+        Some(p) => p,
+        None => crate::vpxz::default_output_path(&expanded_path)?,
+    };
+
+    if output_path.exists() {
+        if output_path.is_dir() {
+            return fail(format!(
+                "Output path exists and is a directory: {}",
+                output_path.display()
+            ));
+        }
+        if !force {
+            let confirmed = confirm(
+                format!("\"{}\" already exists.", output_path.display()),
+                "Do you want to overwrite it?".to_string(),
+            )?;
+            if !confirmed {
+                crate::println!("Aborted")?;
+                return Ok(ExitCode::SUCCESS);
+            }
+        }
+    }
+
+    let loaded_config = config::load_config()?;
+    let config = loaded_config.as_ref().map(|c| &c.1);
+
+    let rom_name = indexer::get_romname_from_vpx(&expanded_path)?;
+    let rom_zip = if bundle_rom {
+        let configured = config.and_then(|c| c.configured_pinmame_folder());
+        let global = config.map(|c| c.global_pinmame_folder());
+        crate::vpxz::find_rom_zip(&expanded_path, configured.as_deref(), global.as_deref())?
+    } else {
+        None
+    };
+
+    let exclude_globs: Vec<String> = config
+        .map(|c| c.vpxz_excludes.clone())
+        .unwrap_or_else(config::default_vpxz_excludes);
+
+    let parent = expanded_path
+        .parent()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    crate::println!("Scanning {parent} ...")?;
+
+    let pb = ProgressBar::hidden();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.green} [{bar:.cyan/blue}] {pos}/{human_len} {msg}")
+            .unwrap(),
+    );
+    pb.set_message("bundling");
+    let progress = ProgressBarProgress::new(pb);
+
+    let report = crate::vpxz::export_vpxz(
+        &expanded_path,
+        &output_path,
+        &crate::vpxz::VpxzExportOptions {
+            exclude_globs: &exclude_globs,
+            rom_zip: rom_zip.as_deref(),
+            progress: Some(&progress),
+        },
+    )?;
+
+    if !report.excluded.is_empty() {
+        crate::println!("Excluded {} files:", report.excluded.len())?;
+        for (path, reason) in &report.excluded {
+            crate::println!("  {path} [{reason}]")?;
+        }
+    }
+    if let Some(rom_path) = &report.injected_rom {
+        crate::println!("Injected rom from {}", rom_path.display())?;
+    }
+    if bundle_rom
+        && let Some(rom_name) = rom_name.as_deref()
+        && !report.rom_bundled(rom_name)
+    {
+        crate::println!(
+            "{}",
+            format!("Note: rom '{rom_name}' not found; not bundled.").truecolor(255, 125, 0)
+        )?;
+    }
+    crate::println!(
+        "Wrote {} ({} included, {} excluded)",
+        report.output.display(),
+        report.included.len(),
+        report.excluded.len()
+    )?;
     Ok(ExitCode::SUCCESS)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ pub struct Config {
     pub diff: Option<String>,
     pub editor: Option<String>,
     pub launch_templates: Option<Vec<LaunchTemplate>>,
+    pub vpxz_excludes: Option<Vec<String>>,
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -45,6 +46,19 @@ pub struct ResolvedConfig {
     pub tables_scan_max_depth: Option<usize>,
     pub diff: Option<String>,
     pub editor: Option<String>,
+    pub vpxz_excludes: Vec<String>,
+}
+
+pub fn default_vpxz_excludes() -> Vec<String> {
+    vec![
+        "Downloads/".to_string(),
+        "downloads/".to_string(),
+        "cache/".to_string(),
+        "**/Thumbs.db".to_string(),
+        "**/.DS_Store".to_string(),
+        "**/*.bak".to_string(),
+        "**/*~".to_string(),
+    ]
 }
 
 impl ResolvedConfig {
@@ -174,6 +188,7 @@ fn read_config(config_path: &Path) -> io::Result<ResolvedConfig> {
         tables_scan_max_depth: config.tables_scan_max_depth,
         diff: config.diff,
         editor: config.editor,
+        vpxz_excludes: config.vpxz_excludes.unwrap_or_else(default_vpxz_excludes),
     };
     Ok(resolved_config)
 }
@@ -392,6 +407,7 @@ fn write_default_config(config_file: &Path, vpx_executable: &Path) -> io::Result
         tables_scan_max_depth: None,
         diff: None,
         editor: None,
+        vpxz_excludes: None,
     };
     write_config(config_file, &config)?;
     Ok(())
@@ -496,6 +512,7 @@ mod tests {
                 tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
+                vpxz_excludes: default_vpxz_excludes(),
             }
         );
         Ok(())
@@ -590,6 +607,7 @@ mod tests {
                 tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
+                vpxz_excludes: default_vpxz_excludes(),
             }
         );
         Ok(())
@@ -626,6 +644,7 @@ mod tests {
                 tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
+                vpxz_excludes: default_vpxz_excludes(),
             }
         );
         Ok(())
@@ -651,6 +670,7 @@ mod tests {
                 tables_scan_max_depth: None,
                 diff: None,
                 editor: None,
+                vpxz_excludes: default_vpxz_excludes(),
                 launch_templates: vec!(LaunchTemplate {
                     name: "Launch".to_string(),
                     executable: PathBuf::from("C:\\test\\vpinball"),

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -57,6 +57,7 @@ enum TableOption {
     B2SAutoPositionDMD,
     EditTableINI,
     EditMainIni,
+    ExportVpxz,
 }
 
 impl TableOption {
@@ -86,6 +87,7 @@ impl TableOption {
             TableOption::B2SAutoPositionDMD,
             TableOption::EditTableINI,
             TableOption::EditMainIni,
+            TableOption::ExportVpxz,
         ]);
         options
     }
@@ -111,6 +113,7 @@ impl TableOption {
             TableOption::B2SAutoPositionDMD => "Backglass > Auto-position DMD".to_string(),
             TableOption::EditTableINI => "INI > Edit table ini".to_string(),
             TableOption::EditMainIni => "INI > Edit main ini".to_string(),
+            TableOption::ExportVpxz => "Export > vpxz (mobile)".to_string(),
         }
     }
 }
@@ -487,6 +490,10 @@ fn table_menu(
                 };
                 report_launch_result(path, result);
             }
+            Some(TableOption::ExportVpxz) => match export_vpxz(config, selected_path, info) {
+                Ok(msg) => prompt(&msg),
+                Err(err) => prompt_error(&format!("Unable to export vpxz: {err}")),
+            },
             None => exit = true,
         }
     }
@@ -745,6 +752,67 @@ fn nvram_clear(info: &IndexedTable) {
     } else {
         prompt("This table is not using used PinMAME");
     }
+}
+
+fn export_vpxz(
+    config: &ResolvedConfig,
+    selected_path: &Path,
+    info: &IndexedTable,
+) -> io::Result<String> {
+    let output_path = crate::vpxz::default_output_path(selected_path)?;
+
+    if output_path.exists()
+        && !Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(format!(
+                "\"{}\" already exists. Overwrite?",
+                output_path.display()
+            ))
+            .default(false)
+            .interact()
+            .unwrap_or(false)
+    {
+        return Ok("Aborted".to_string());
+    }
+
+    let rom_zip = info.rom_path().filter(|p| p.is_file()).cloned();
+    let rom_name = indexer::get_romname_from_vpx(selected_path).ok().flatten();
+
+    let pb = ProgressBar::hidden();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.green} [{bar:.cyan/blue}] {pos}/{human_len} {msg}")
+            .unwrap(),
+    );
+    pb.set_message("bundling");
+    let progress = ProgressBarProgress::new(pb);
+
+    let report = crate::vpxz::export_vpxz(
+        selected_path,
+        &output_path,
+        &crate::vpxz::VpxzExportOptions {
+            exclude_globs: &config.vpxz_excludes,
+            rom_zip: rom_zip.as_deref(),
+            progress: Some(&progress),
+        },
+    )?;
+
+    let mut msg = format!("Included {} files", report.included.len());
+    if !report.excluded.is_empty() {
+        msg.push_str(&format!(", excluded {}", report.excluded.len()));
+    }
+    if let Some(rom_path) = &report.injected_rom {
+        msg.push_str(&format!("\nInjected rom from {}", rom_path.display()));
+    }
+    let rom_bundled = rom_name
+        .as_deref()
+        .map(|n| report.rom_bundled(n))
+        .unwrap_or(false);
+    if info.requires_pinmame && !rom_bundled {
+        msg.push_str(
+            "\nNote: this table requires PinMAME but no rom file was located; not bundled.",
+        );
+    }
+    msg.push_str(&format!("\nWrote {}", report.output.display()));
+    Ok(msg)
 }
 
 /// Find the NVRAM file for a ROM, not checking if it exists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod indexer;
 pub mod cli;
 mod colorful_theme_patched;
 pub mod vpinball_config;
+pub mod vpxz;
 
 pub fn strip_cr_lf(s: &str) -> String {
     s.chars().filter(|c| !c.is_ascii_whitespace()).collect()

--- a/src/vpxz.rs
+++ b/src/vpxz.rs
@@ -1,0 +1,673 @@
+//! Build a `.vpxz` archive (a renamed zip) for transfer to the Visual Pinball
+//! mobile app.
+//!
+//! Strategy: bundle the vpx's parent folder recursively, dropping
+//! - any *other* `*.vpx` files (the mobile importer rejects archives with more
+//!   than one .vpx),
+//! - same-directory stem-keyed sidecars of each other vpx,
+//! - any `.directb2s` whose stem does not match the chosen vpx,
+//! - anything matching a user-configured glob in `vpxz_excludes`.
+//!
+//! Optionally inject the matching pinmame rom zip from a configured pinmame
+//! folder if it is not already present in the source tree.
+
+use crate::indexer;
+use crate::indexer::Progress;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter};
+use std::path::{Path, PathBuf};
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
+
+pub struct VpxzExportOptions<'a> {
+    /// User-configured glob patterns (gitignore-ish) of paths to exclude,
+    /// matched relative to the vpx's parent folder.
+    pub exclude_globs: &'a [String],
+    /// Absolute path to a rom zip to inject as `pinmame/roms/<basename>` if it
+    /// is not already present somewhere inside the vpx's parent folder.
+    pub rom_zip: Option<&'a Path>,
+    /// Optional progress sink. `set_length` is called once after the directory
+    /// walk with the file count, then `set_position` once per file as it is
+    /// processed (included or excluded), and `finish_and_clear` at the end.
+    pub progress: Option<&'a dyn Progress>,
+}
+
+#[derive(Debug)]
+pub struct VpxzReport {
+    pub output: PathBuf,
+    /// Archive-relative paths actually written, in insertion order.
+    pub included: Vec<String>,
+    /// Source-relative paths dropped, paired with the reason they were dropped.
+    pub excluded: Vec<(String, ExcludeReason)>,
+    /// Source path of a rom we injected from outside the tree, if any.
+    pub injected_rom: Option<PathBuf>,
+}
+
+impl VpxzReport {
+    /// Whether a `pinmame/roms/<rom_name>.zip` ended up in the archive, either
+    /// from the source tree or via injection. Case-insensitive on the file name.
+    pub fn rom_bundled(&self, rom_name: &str) -> bool {
+        let suffix = format!("pinmame/roms/{}.zip", rom_name.to_lowercase());
+        self.included
+            .iter()
+            .any(|p| p.to_lowercase().ends_with(&suffix))
+    }
+}
+
+/// Why a file under the vpx's parent folder did not end up in the archive.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ExcludeReason {
+    /// Another `.vpx` file in the tree; the mobile importer rejects archives
+    /// that contain more than one .vpx.
+    OtherVpx,
+    /// Same directory and stem as an excluded `OtherVpx`; treated as that
+    /// other vpx's sidecar.
+    OtherVpxSidecar,
+    /// `.directb2s` whose stem doesn't match the chosen vpx's stem.
+    UnrelatedDirectb2s,
+    /// A previously generated `.vpxz` archive sitting in the tree.
+    VpxzArchive,
+    /// Matched a user-configured glob in `vpxz_excludes`.
+    UserGlob,
+}
+
+impl std::fmt::Display for ExcludeReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ExcludeReason::OtherVpx => "other_vpx",
+            ExcludeReason::OtherVpxSidecar => "other_vpx_sidecar",
+            ExcludeReason::UnrelatedDirectb2s => "unrelated_directb2s",
+            ExcludeReason::VpxzArchive => "vpxz_archive",
+            ExcludeReason::UserGlob => "vpxz_excludes",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Write a vpxz archive containing the table and its assets.
+pub fn export_vpxz(
+    vpx_path: &Path,
+    output_path: &Path,
+    options: &VpxzExportOptions,
+) -> io::Result<VpxzReport> {
+    let stem = vpx_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("vpx path has no usable file stem: {}", vpx_path.display()),
+            )
+        })?
+        .to_string();
+    let parent = vpx_path
+        .parent()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("vpx path has no parent directory: {}", vpx_path.display()),
+            )
+        })?
+        .to_path_buf();
+
+    let exclude_set = build_glob_set(options.exclude_globs)?;
+    let auto_excluded_paths = collect_auto_excluded_paths(&parent, vpx_path, &stem)?;
+
+    let file = File::create(output_path)?;
+    let mut zip = ZipWriter::new(BufWriter::new(file));
+    let file_opts =
+        SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    let mut included = Vec::new();
+    let mut excluded = Vec::new();
+    let mut rom_already_in_tree = false;
+
+    let entries = walkdir(&parent)?;
+    if let Some(p) = options.progress {
+        p.set_length(entries.len() as u64);
+    }
+
+    for (i, entry) in entries.into_iter().enumerate() {
+        let abs = entry.path;
+        let rel = abs.strip_prefix(&parent).unwrap();
+        let rel_str = rel.to_string_lossy().into_owned();
+
+        if let Some(reason) = auto_excluded_paths.get(&abs) {
+            excluded.push((rel_str, *reason));
+        } else if exclude_set.is_match(rel) {
+            excluded.push((rel_str, ExcludeReason::UserGlob));
+        } else {
+            let rel_archive = to_archive_path(rel);
+            let archive_path = format!("{stem}/{rel_archive}");
+            if let Some(rom_zip) = options.rom_zip
+                && let Some(rom_name_lower) = file_name_lower(rom_zip)
+                && rel_archive
+                    .to_lowercase()
+                    .ends_with(&format!("pinmame/roms/{rom_name_lower}"))
+            {
+                rom_already_in_tree = true;
+            }
+            add_file(&mut zip, &abs, &archive_path, file_opts)?;
+            included.push(archive_path);
+        }
+
+        if let Some(p) = options.progress {
+            p.set_position((i + 1) as u64);
+        }
+    }
+
+    let mut injected_rom = None;
+    if let Some(rom_zip) = options.rom_zip
+        && !rom_already_in_tree
+        && rom_zip.is_file()
+    {
+        let rom_name = rom_zip
+            .file_name()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("rom zip path has no file name: {}", rom_zip.display()),
+                )
+            })?;
+        let archive_path = format!("{stem}/pinmame/roms/{rom_name}");
+        add_file(&mut zip, rom_zip, &archive_path, file_opts)?;
+        included.push(archive_path);
+        injected_rom = Some(rom_zip.to_path_buf());
+    }
+
+    zip.finish().map_err(io::Error::other)?;
+    if let Some(p) = options.progress {
+        p.finish_and_clear();
+    }
+
+    Ok(VpxzReport {
+        output: output_path.to_path_buf(),
+        included,
+        excluded,
+        injected_rom,
+    })
+}
+
+/// Locate the rom zip for a vpx: read the script for the rom name, then probe
+/// the configured / global pinmame folders. Returns `Ok(None)` for non-PinMAME
+/// tables or when no rom file can be located.
+pub fn find_rom_zip(
+    vpx_path: &Path,
+    configured_pinmame_folder: Option<&Path>,
+    global_pinmame_folder: Option<&Path>,
+) -> io::Result<Option<PathBuf>> {
+    let Some(rom_name) = indexer::get_romname_from_vpx(vpx_path)? else {
+        return Ok(None);
+    };
+    let rom_file = format!("{}.zip", rom_name.to_lowercase());
+    let vpx_parent = vpx_path.parent().unwrap_or(Path::new("."));
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(p) = configured_pinmame_folder {
+        let base = if p.is_relative() {
+            vpx_parent.join(p)
+        } else {
+            p.to_path_buf()
+        };
+        candidates.push(base.join("roms").join(&rom_file));
+    }
+    if let Some(p) = global_pinmame_folder {
+        candidates.push(p.join("roms").join(&rom_file));
+    }
+    Ok(candidates.into_iter().find(|p| p.is_file()))
+}
+
+/// Default output path for a vpxz: parent of the vpx's directory.
+pub fn default_output_path(vpx_path: &Path) -> io::Result<PathBuf> {
+    let stem = vpx_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("vpx path has no usable file stem: {}", vpx_path.display()),
+            )
+        })?;
+    let parent = vpx_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("vpx path has no parent directory: {}", vpx_path.display()),
+        )
+    })?;
+    let grandparent = parent.parent().unwrap_or(parent);
+    Ok(grandparent.join(format!("{stem}.vpxz")))
+}
+
+fn build_glob_set(patterns: &[String]) -> io::Result<GlobSet> {
+    let mut builder = GlobSetBuilder::new();
+    for raw in patterns {
+        // Allow trailing "/" to mean "this directory and everything under it",
+        // both at the top level and anywhere in the tree. We expand `Foo/` to
+        // two globs: `Foo/**` (top-level) and `**/Foo/**` (nested).
+        let raw = raw.trim();
+        if let Some(dir) = raw.strip_suffix('/') {
+            let dir = dir.trim_start_matches("./");
+            builder.add(glob_or_err(&format!("{dir}/**"))?);
+            builder.add(glob_or_err(&format!("**/{dir}/**"))?);
+        } else {
+            builder.add(glob_or_err(raw)?);
+        }
+    }
+    builder.build().map_err(io::Error::other)
+}
+
+fn glob_or_err(s: &str) -> io::Result<Glob> {
+    Glob::new(s).map_err(|e| io::Error::other(format!("invalid vpxz_excludes glob '{s}': {e}")))
+}
+
+fn collect_auto_excluded_paths(
+    root: &Path,
+    chosen_vpx: &Path,
+    chosen_stem: &str,
+) -> io::Result<HashMap<PathBuf, ExcludeReason>> {
+    let mut excludes: HashMap<PathBuf, ExcludeReason> = HashMap::new();
+
+    // Pass 1: find every other .vpx and their stem-keyed sidecars.
+    let mut other_stems_by_dir: HashMap<PathBuf, HashSet<String>> = HashMap::new();
+    for entry in walkdir(root)? {
+        let p = &entry.path;
+        if path_has_extension(p, "vpx") && p != chosen_vpx {
+            excludes.insert(p.clone(), ExcludeReason::OtherVpx);
+            if let (Some(parent), Some(stem)) = (p.parent(), p.file_stem().and_then(|s| s.to_str()))
+            {
+                other_stems_by_dir
+                    .entry(parent.to_path_buf())
+                    .or_default()
+                    .insert(stem.to_string());
+            }
+        }
+    }
+
+    // Pass 2: anything sharing a directory and an exact stem with an excluded
+    // other-vpx is itself excluded as a sidecar.
+    for entry in walkdir(root)? {
+        let p = &entry.path;
+        if excludes.contains_key(p) {
+            continue;
+        }
+        if let (Some(parent), Some(stem)) = (p.parent(), p.file_stem().and_then(|s| s.to_str()))
+            && other_stems_by_dir
+                .get(parent)
+                .map(|s| s.contains(stem))
+                .unwrap_or(false)
+        {
+            excludes.insert(p.clone(), ExcludeReason::OtherVpxSidecar);
+        }
+    }
+
+    // Pass 3: .directb2s files whose stem does not match the chosen vpx.
+    for entry in walkdir(root)? {
+        let p = &entry.path;
+        if excludes.contains_key(p) {
+            continue;
+        }
+        if path_has_extension(p, "directb2s")
+            && p.file_stem().and_then(|s| s.to_str()) != Some(chosen_stem)
+        {
+            excludes.insert(p.clone(), ExcludeReason::UnrelatedDirectb2s);
+        }
+    }
+
+    // Pass 4: any .vpxz files - we never bundle a previous archive into a new
+    // one, regardless of where it sits in the tree.
+    for entry in walkdir(root)? {
+        let p = &entry.path;
+        if excludes.contains_key(p) {
+            continue;
+        }
+        if path_has_extension(p, "vpxz") {
+            excludes.insert(p.clone(), ExcludeReason::VpxzArchive);
+        }
+    }
+
+    Ok(excludes)
+}
+
+struct WalkEntry {
+    path: PathBuf,
+}
+
+/// Depth-first walk yielding only files (no directories, no symlinks).
+fn walkdir(root: &Path) -> io::Result<Vec<WalkEntry>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let read = match std::fs::read_dir(&dir) {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("vpxz: cannot read {}: {e}", dir.display());
+                continue;
+            }
+        };
+        for entry in read.flatten() {
+            let path = entry.path();
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(e) => {
+                    log::warn!("vpxz: cannot stat {}: {e}", path.display());
+                    continue;
+                }
+            };
+            if ft.is_symlink() {
+                continue;
+            }
+            if ft.is_dir() {
+                stack.push(path);
+            } else if ft.is_file() {
+                out.push(WalkEntry { path });
+            }
+        }
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+fn path_has_extension(p: &Path, ext: &str) -> bool {
+    p.extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.eq_ignore_ascii_case(ext))
+        .unwrap_or(false)
+}
+
+fn file_name_lower(p: &Path) -> Option<String> {
+    p.file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_lowercase())
+}
+
+fn to_archive_path(rel: &Path) -> String {
+    rel.components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn add_file(
+    zip: &mut ZipWriter<BufWriter<File>>,
+    src: &Path,
+    archive_path: &str,
+    options: SimpleFileOptions,
+) -> io::Result<()> {
+    zip.start_file(archive_path, options)
+        .map_err(io::Error::other)?;
+    let mut reader = BufReader::new(File::open(src)?);
+    io::copy(&mut reader, zip)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::io::Read;
+    use std::io::Write;
+    use testdir::testdir;
+
+    fn write_bytes(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = File::create(path).unwrap();
+        f.write_all(bytes).unwrap();
+    }
+
+    fn archive_entries(vpxz: &Path) -> BTreeSet<String> {
+        let reader = BufReader::new(File::open(vpxz).unwrap());
+        let mut archive = zip::ZipArchive::new(reader).unwrap();
+        (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect()
+    }
+
+    fn archive_bytes(vpxz: &Path, name: &str) -> Vec<u8> {
+        let reader = BufReader::new(File::open(vpxz).unwrap());
+        let mut archive = zip::ZipArchive::new(reader).unwrap();
+        let mut entry = archive.by_name(name).unwrap();
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf).unwrap();
+        buf
+    }
+
+    #[test]
+    fn bundles_lone_vpx() {
+        let dir = testdir!();
+        let table_dir = dir.join("MyTable");
+        let vpx = table_dir.join("MyTable.vpx");
+        write_bytes(&vpx, b"vpx");
+
+        let out = dir.join("MyTable.vpxz");
+        let report = export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &[],
+                rom_zip: None,
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            archive_entries(&out),
+            BTreeSet::from(["MyTable/MyTable.vpx".to_string()])
+        );
+        assert!(report.excluded.is_empty());
+        assert!(report.injected_rom.is_none());
+    }
+
+    #[test]
+    fn excludes_other_vpx_and_their_sidecars() {
+        let dir = testdir!();
+        let table_dir = dir.join("MyTable");
+        let vpx = table_dir.join("MyTable v1.1.vpx");
+        write_bytes(&vpx, b"v1.1");
+        write_bytes(&table_dir.join("MyTable v1.1.vbs"), b"v1.1-vbs");
+        write_bytes(&table_dir.join("MyTable v1.0.vpx"), b"v1.0");
+        write_bytes(&table_dir.join("MyTable v1.0.vbs"), b"v1.0-vbs");
+        write_bytes(&table_dir.join("MyTable v1.0.ini"), b"v1.0-ini");
+        // A shared backglass that does NOT match the chosen stem -> excluded.
+        write_bytes(&table_dir.join("MyTable.directb2s"), b"b2s");
+        // pinmame folder is preserved untouched
+        write_bytes(&table_dir.join("pinmame/roms/foo.zip"), b"rom");
+
+        let out = dir.join("out.vpxz");
+        let report = export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &[],
+                rom_zip: None,
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        let expected: BTreeSet<String> = [
+            "MyTable v1.1/MyTable v1.1.vpx",
+            "MyTable v1.1/MyTable v1.1.vbs",
+            "MyTable v1.1/pinmame/roms/foo.zip",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(archive_entries(&out), expected);
+
+        let excluded_reasons: BTreeSet<ExcludeReason> =
+            report.excluded.iter().map(|(_, r)| *r).collect();
+        assert!(excluded_reasons.contains(&ExcludeReason::OtherVpx));
+        assert!(excluded_reasons.contains(&ExcludeReason::OtherVpxSidecar));
+        assert!(excluded_reasons.contains(&ExcludeReason::UnrelatedDirectb2s));
+    }
+
+    #[test]
+    fn keeps_directb2s_matching_chosen_stem() {
+        let dir = testdir!();
+        let table_dir = dir.join("Table");
+        let vpx = table_dir.join("Table.vpx");
+        write_bytes(&vpx, b"vpx");
+        write_bytes(&table_dir.join("Table.directb2s"), b"b2s");
+
+        let out = dir.join("Table.vpxz");
+        export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &[],
+                rom_zip: None,
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            archive_entries(&out),
+            BTreeSet::from([
+                "Table/Table.vpx".to_string(),
+                "Table/Table.directb2s".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn applies_user_exclude_patterns() {
+        let dir = testdir!();
+        let table_dir = dir.join("Table");
+        let vpx = table_dir.join("Table.vpx");
+        write_bytes(&vpx, b"vpx");
+        write_bytes(&table_dir.join("Downloads/Original.zip"), b"junk");
+        write_bytes(&table_dir.join("subdir/Thumbs.db"), b"junk");
+        write_bytes(&table_dir.join("good.txt"), b"good");
+
+        let out = dir.join("Table.vpxz");
+        export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &["Downloads/".to_string(), "**/Thumbs.db".to_string()],
+                rom_zip: None,
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        let entries = archive_entries(&out);
+        assert!(entries.contains("Table/Table.vpx"));
+        assert!(entries.contains("Table/good.txt"));
+        assert!(
+            !entries.iter().any(|e| e.contains("Downloads")),
+            "Downloads/ should be excluded: {entries:?}"
+        );
+        assert!(
+            !entries.iter().any(|e| e.contains("Thumbs.db")),
+            "Thumbs.db should be excluded: {entries:?}"
+        );
+    }
+
+    #[test]
+    fn injects_rom_when_not_already_in_tree() {
+        let dir = testdir!();
+        let table_dir = dir.join("Table");
+        let vpx = table_dir.join("Table.vpx");
+        write_bytes(&vpx, b"vpx");
+        let rom = dir.join("global_pinmame/roms/mygame.zip");
+        write_bytes(&rom, b"rom-bytes");
+
+        let out = dir.join("Table.vpxz");
+        let report = export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &[],
+                rom_zip: Some(&rom),
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        let entries = archive_entries(&out);
+        assert!(entries.contains("Table/pinmame/roms/mygame.zip"));
+        assert_eq!(
+            archive_bytes(&out, "Table/pinmame/roms/mygame.zip"),
+            b"rom-bytes"
+        );
+        assert_eq!(report.injected_rom.as_deref(), Some(rom.as_path()));
+    }
+
+    #[test]
+    fn does_not_double_inject_rom_already_present() {
+        let dir = testdir!();
+        let table_dir = dir.join("Table");
+        let vpx = table_dir.join("Table.vpx");
+        write_bytes(&vpx, b"vpx");
+        let tree_rom = table_dir.join("pinmame/roms/mygame.zip");
+        write_bytes(&tree_rom, b"rom-in-tree");
+        let global_rom = dir.join("global/mygame.zip");
+        write_bytes(&global_rom, b"rom-from-global");
+
+        let out = dir.join("Table.vpxz");
+        let report = export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &[],
+                rom_zip: Some(&global_rom),
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        let entries = archive_entries(&out);
+        assert!(entries.contains("Table/pinmame/roms/mygame.zip"));
+        // The in-tree copy wins (no overwrite, no duplicate entry).
+        assert_eq!(
+            archive_bytes(&out, "Table/pinmame/roms/mygame.zip"),
+            b"rom-in-tree"
+        );
+        assert!(report.injected_rom.is_none());
+    }
+
+    #[test]
+    fn always_excludes_prior_vpxz_archives() {
+        let dir = testdir!();
+        let table_dir = dir.join("Table");
+        let vpx = table_dir.join("Table.vpx");
+        write_bytes(&vpx, b"vpx");
+        // A previous export, either next to the vpx or nested deeper:
+        write_bytes(&table_dir.join("Table.vpxz"), b"old");
+        write_bytes(&table_dir.join("subdir/another.vpxz"), b"old2");
+
+        let out = dir.join("Table.vpxz");
+        let report = export_vpxz(
+            &vpx,
+            &out,
+            &VpxzExportOptions {
+                exclude_globs: &[],
+                rom_zip: None,
+                progress: None,
+            },
+        )
+        .unwrap();
+
+        let entries = archive_entries(&out);
+        assert!(!entries.iter().any(|e| e.ends_with(".vpxz")));
+        let reasons: BTreeSet<ExcludeReason> = report.excluded.iter().map(|(_, r)| *r).collect();
+        assert!(reasons.contains(&ExcludeReason::VpxzArchive));
+    }
+
+    #[test]
+    fn default_output_path_uses_grandparent_and_stem() {
+        let p = Path::new("/tables/My Table/Table v1.1.vpx");
+        assert_eq!(
+            default_output_path(p).unwrap(),
+            PathBuf::from("/tables/Table v1.1.vpxz")
+        );
+    }
+}


### PR DESCRIPTION
Closes #747.

## Summary

Adds `vpxtool export vpxz <vpx>` (and a matching "Export > vpxz (mobile)" entry in the frontend table menu) for bundling a table into a `.vpxz` archive that the Visual Pinball iOS/Android app accepts.

The mobile importer rejects archives with more than one `.vpx` inside, so the bundler is selective: it walks the chosen vpx's parent folder and drops

- other `.vpx` files (`other_vpx`),
- same-directory stem-keyed sidecars of each other vpx (`other_vpx_sidecar`),
- any `.directb2s` whose stem does not match the chosen vpx (`unrelated_directb2s`),
- anything matching a user glob in the new `vpxz_excludes` config key.

Defaults for `vpxz_excludes`:

```toml
vpxz_excludes = ["Downloads/", "downloads/", "**/Thumbs.db", "**/.DS_Store", "**/*.bak", "**/*~"]
```

For PinMAME tables, the matching rom zip is injected from the configured pinmame folder when not already present inside the tree.

Default output path is `<vpx_parent>/../<stem>.vpxz` (one level up from the vpx's folder, named after the chosen vpx stem).

## Test plan

- [x] `cargo test` (68 lib tests, +6 new vpxz tests)
- [x] `cargo clippy --all-targets` clean
- [x] End-to-end smoke test against a synthetic multi-version folder (v1.0 + v1.1 + folder-named `.directb2s` + `pupvideos/` + `Downloads/` + `Thumbs.db`) - correct files included/excluded with reasons logged
- [ ] Try a real export and load it in the iOS or Android Visual Pinball app