### PR TITLE
feat(cli): add nvram show subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Commands:
   config          Vpxtool related config file
   images          Vpx image related commands
   gamedata        Vpx gamedata related commands
+  nvram           PinMAME NVRAM related commands
   romname         Prints the PinMAME ROM name from a vpx file
   export          Export a vpx table to obj/gltf/glb or to a vpxz mobile archive
   help            Print this message or the help of the given subcommand(s)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,9 @@ const CMD_GAMEDATA_SHOW: &str = "show";
 const CMD_DIPSWITCHES: &str = "dipswitches";
 const CMD_DIPSWITCHES_SHOW: &str = "show";
 
+const CMD_NVRAM: &str = "nvram";
+const CMD_NVRAM_SHOW: &str = "show";
+
 const CMD_ROMNAME: &str = "romname";
 
 const CMD_EXPORT: &str = "export";
@@ -743,6 +746,10 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             }
             Ok(ExitCode::SUCCESS)
         }
+        Some((CMD_NVRAM, sub_matches)) => match sub_matches.subcommand() {
+            Some((CMD_NVRAM_SHOW, sub_matches)) => handle_nvram_show(sub_matches),
+            _ => unreachable!(),
+        },
         Some((CMD_EXPORT, sub_matches)) => match sub_matches.subcommand() {
             Some((CMD_EXPORT_OBJ, sub_matches)) => handle_export_obj(sub_matches),
             Some((CMD_EXPORT_GLTF, sub_matches)) => handle_export_gltf(sub_matches),
@@ -1144,6 +1151,22 @@ fn build_command() -> Command {
                 ),
         )
         .subcommand(
+            Command::new(CMD_NVRAM)
+                .subcommand_required(true)
+                .about("PinMAME NVRAM related commands")
+                .subcommand(
+                    Command::new(CMD_NVRAM_SHOW)
+                        .about("Resolve a PinMAME NVRAM file to JSON")
+                        .long_about(
+                            "Resolve a PinMAME NVRAM file to JSON using the pinmame-nvram maps. \
+                             PATH may be a .vpx (the .nv is located via the configured/global \
+                             pinmame folders), a .nv (resolved directly), or a rom .zip (the \
+                             sibling ../nvram/<stem>.nv is used).",
+                        )
+                        .arg(arg!(<PATH> "Path to a .vpx, .nv, or rom .zip file").required(true)),
+                ),
+        )
+        .subcommand(
             Command::new(CMD_ROMNAME)
                 .about("Prints the PinMAME ROM name from a vpx file")
                 .long_about("Extracts the PinMAME ROM name from a vpx file by searching for specific patterns in the table script. If the table is not PinMAME based, no output is produced.")
@@ -1481,6 +1504,90 @@ fn handle_export_vpxz(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
         report.excluded.len()
     )?;
     Ok(ExitCode::SUCCESS)
+}
+
+fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
+    let path = sub_matches
+        .get_one::<String>("PATH")
+        .map(|s| s.as_str())
+        .unwrap_or_default();
+    let expanded_path = path_exists(path)?;
+
+    let nvram_path = match expanded_path
+        .extension()
+        .and_then(OsStr::to_str)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("nv") => expanded_path.clone(),
+        Some("zip") => {
+            // Treat as a rom zip: nvram lives at ../nvram/<stem>.nv.
+            let stem = expanded_path
+                .file_stem()
+                .and_then(OsStr::to_str)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("rom zip has no usable file stem: {}", expanded_path.display()),
+                    )
+                })?;
+            let candidate = expanded_path
+                .parent()
+                .and_then(Path::parent)
+                .map(|p| p.join("nvram").join(format!("{stem}.nv")));
+            match candidate.filter(|p| p.is_file()) {
+                Some(p) => p,
+                None => return fail(format!(
+                    "No nvram file found next to rom zip {}",
+                    expanded_path.display()
+                )),
+            }
+        }
+        Some("vpx") => {
+            if indexer::get_romname_from_vpx(&expanded_path)?.is_none() {
+                return fail(format!(
+                    "Table {} is not PinMAME-based",
+                    expanded_path.display()
+                ));
+            }
+            let loaded_config = config::load_config()?;
+            let config = loaded_config.as_ref().map(|c| &c.1);
+            let configured = config.and_then(|c| c.configured_pinmame_folder());
+            let global = config.map(|c| c.global_pinmame_folder());
+            match indexer::find_nvram_for_vpx(
+                &expanded_path,
+                configured.as_deref(),
+                global.as_deref(),
+            )? {
+                Some(p) => p,
+                None => return fail(format!(
+                    "No nvram file found for {} - try launching the table once",
+                    expanded_path.display()
+                )),
+            }
+        }
+        _ => return fail(format!(
+            "Unsupported file type: {} (expected .vpx, .nv, or rom .zip)",
+            expanded_path.display()
+        )),
+    };
+
+    match pinmame_nvram::resolve::resolve(&nvram_path) {
+        Ok(Some(resolved)) => {
+            let json = serde_json::to_string_pretty(&resolved)
+                .map_err(|e| io::Error::other(format!("Failed to serialize nvram json: {e}")))?;
+            crate::println!("{json}")?;
+            Ok(ExitCode::SUCCESS)
+        }
+        Ok(None) => fail(format!(
+            "No pinmame-nvram map for {}",
+            nvram_path.display()
+        )),
+        Err(e) => fail(format!(
+            "Failed to resolve nvram {}: {e}",
+            nvram_path.display()
+        )),
+    }
 }
 
 fn extract_script_command(name: impl Into<Str>) -> Command {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1528,7 +1528,10 @@ fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
                 .ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidInput,
-                        format!("rom zip has no usable file stem: {}", expanded_path.display()),
+                        format!(
+                            "rom zip has no usable file stem: {}",
+                            expanded_path.display()
+                        ),
                     )
                 })?;
             let candidate = expanded_path
@@ -1537,10 +1540,12 @@ fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
                 .map(|p| p.join("nvram").join(format!("{stem}.nv")));
             match candidate.filter(|p| p.is_file()) {
                 Some(p) => p,
-                None => return fail(format!(
-                    "No nvram file found next to rom zip {}",
-                    expanded_path.display()
-                )),
+                None => {
+                    return fail(format!(
+                        "No nvram file found next to rom zip {}",
+                        expanded_path.display()
+                    ));
+                }
             }
         }
         Some("vpx") => {
@@ -1560,16 +1565,20 @@ fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
                 global.as_deref(),
             )? {
                 Some(p) => p,
-                None => return fail(format!(
-                    "No nvram file found for {} - try launching the table once",
-                    expanded_path.display()
-                )),
+                None => {
+                    return fail(format!(
+                        "No nvram file found for {} - try launching the table once",
+                        expanded_path.display()
+                    ));
+                }
             }
         }
-        _ => return fail(format!(
-            "Unsupported file type: {} (expected .vpx, .nv, or rom .zip)",
-            expanded_path.display()
-        )),
+        _ => {
+            return fail(format!(
+                "Unsupported file type: {} (expected .vpx, .nv, or rom .zip)",
+                expanded_path.display()
+            ));
+        }
     };
 
     match pinmame_nvram::resolve::resolve(&nvram_path) {
@@ -1579,10 +1588,7 @@ fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             crate::println!("{json}")?;
             Ok(ExitCode::SUCCESS)
         }
-        Ok(None) => fail(format!(
-            "No pinmame-nvram map for {}",
-            nvram_path.display()
-        )),
+        Ok(None) => fail(format!("No pinmame-nvram map for {}", nvram_path.display())),
         Err(e) => fail(format!(
             "Failed to resolve nvram {}: {e}",
             nvram_path.display()

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -644,6 +644,56 @@ fn read_table_info_json(info_file_path: &Path) -> io::Result<TableInfo> {
     Ok(table_info)
 }
 
+/// Locate the `.nv` file for a vpx by reading the script for the rom name and
+/// then probing the same set of pinmame folders the indexer uses for roms:
+///   1. configured PinMAMEPath (resolved relative to the vpx if relative)
+///   2. `<vpx_parent>/pinmame` (vpinball's local fallback)
+///   3. global pinmame folder (`~/.pinmame` or `VPinMAME` on Windows)
+///
+/// Returns `Ok(None)` for non-PinMAME tables or when no `.nv` file is found.
+pub fn find_nvram_for_vpx(
+    vpx_path: &Path,
+    configured_pinmame_folder: Option<&Path>,
+    global_pinmame_folder: Option<&Path>,
+) -> io::Result<Option<PathBuf>> {
+    let Some(rom_name) = get_romname_from_vpx(vpx_path)? else {
+        return Ok(None);
+    };
+    Ok(find_nvram_for_rom(
+        &rom_name,
+        vpx_path,
+        configured_pinmame_folder,
+        global_pinmame_folder,
+    ))
+}
+
+/// Find a `<rom>.nv` file by probing, in order: the configured PinMAMEPath, the
+/// `<vpx_parent>/pinmame` local fallback, and the global pinmame folder.
+fn find_nvram_for_rom(
+    rom_name: &str,
+    vpx_path: &Path,
+    configured_pinmame_folder: Option<&Path>,
+    global_pinmame_folder: Option<&Path>,
+) -> Option<PathBuf> {
+    let nv_file = format!("{}.nv", rom_name.to_lowercase());
+    let vpx_parent = vpx_path.parent().unwrap_or(Path::new("."));
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(p) = configured_pinmame_folder {
+        let base = if p.is_relative() {
+            vpx_parent.join(p)
+        } else {
+            p.to_path_buf()
+        };
+        candidates.push(base.join("nvram").join(&nv_file));
+    }
+    candidates.push(vpx_parent.join("pinmame").join("nvram").join(&nv_file));
+    if let Some(p) = global_pinmame_folder {
+        candidates.push(p.join("nvram").join(&nv_file));
+    }
+    candidates.into_iter().find(|p| p.is_file())
+}
+
 /// Visual pinball always falls back to the [vpx_folder]/pinmame/roms folder,
 /// even if the PinMAMEPath folder is configured in the vpinball config.
 fn find_local_rom_path(
@@ -1537,6 +1587,90 @@ LoadVPM "01210000","sys80.vbs",3.10
         )
         .unwrap();
         assert_eq!(local_rom, Some(expected_rom_path));
+    }
+
+    #[test]
+    fn test_find_nvram_prefers_configured_pinmame_folder() {
+        let dir = testdir!();
+        let vpx_path = dir.join("test.vpx");
+        let configured = dir.join("configured");
+        let global = dir.join("global");
+        let local_fallback = dir.join("pinmame");
+        for base in [&configured, &global, &local_fallback] {
+            fs::create_dir_all(base.join("nvram")).unwrap();
+        }
+        let configured_nv = configured.join("nvram").join("rom1.nv");
+        File::create(&configured_nv).unwrap();
+        File::create(local_fallback.join("nvram").join("rom1.nv")).unwrap();
+        File::create(global.join("nvram").join("rom1.nv")).unwrap();
+
+        let found = find_nvram_for_rom("rom1", &vpx_path, Some(&configured), Some(&global));
+        assert_eq!(found, Some(configured_nv));
+    }
+
+    #[test]
+    fn test_find_nvram_falls_back_to_local_pinmame_folder() {
+        let dir = testdir!();
+        let vpx_path = dir.join("test.vpx");
+        let configured = dir.join("configured");
+        let global = dir.join("global");
+        fs::create_dir_all(dir.join("pinmame").join("nvram")).unwrap();
+        let expected = dir.join("pinmame").join("nvram").join("rom1.nv");
+        File::create(&expected).unwrap();
+
+        let found = find_nvram_for_rom("rom1", &vpx_path, Some(&configured), Some(&global));
+        assert_eq!(found, Some(expected));
+    }
+
+    #[test]
+    fn test_find_nvram_falls_back_to_global_pinmame_folder() {
+        let dir = testdir!();
+        let vpx_path = dir.join("test.vpx");
+        let global = dir.join("global");
+        fs::create_dir_all(global.join("nvram")).unwrap();
+        let expected = global.join("nvram").join("rom1.nv");
+        File::create(&expected).unwrap();
+
+        let found = find_nvram_for_rom("rom1", &vpx_path, None, Some(&global));
+        assert_eq!(found, Some(expected));
+    }
+
+    #[test]
+    fn test_find_nvram_lowercases_rom_name() {
+        let dir = testdir!();
+        let vpx_path = dir.join("test.vpx");
+        let global = dir.join("global");
+        fs::create_dir_all(global.join("nvram")).unwrap();
+        let expected = global.join("nvram").join("rom1.nv");
+        File::create(&expected).unwrap();
+
+        let found = find_nvram_for_rom("ROM1", &vpx_path, None, Some(&global));
+        assert_eq!(found, Some(expected));
+    }
+
+    #[test]
+    fn test_find_nvram_returns_none_when_missing() {
+        let dir = testdir!();
+        let vpx_path = dir.join("test.vpx");
+        let found = find_nvram_for_rom("rom1", &vpx_path, None, None);
+        assert_eq!(found, None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_find_nvram_resolves_relative_configured_folder() {
+        // Mirrors test_find_local_rom_path_relative_linux: on Batocera the
+        // PinMAMEPath can be configured as ./, so it must resolve relative to
+        // the vpx parent.
+        let dir = testdir!();
+        let vpx_path = dir.join("test.vpx");
+        let expected = dir.join("nvram").join("rom1.nv");
+        fs::create_dir_all(expected.parent().unwrap()).unwrap();
+        File::create(&expected).unwrap();
+
+        let found =
+            find_nvram_for_rom("rom1", &vpx_path, Some(&PathBuf::from("./")), None);
+        assert_eq!(found, Some(expected));
     }
 
     #[cfg(target_os = "linux")]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1668,8 +1668,7 @@ LoadVPM "01210000","sys80.vbs",3.10
         fs::create_dir_all(expected.parent().unwrap()).unwrap();
         File::create(&expected).unwrap();
 
-        let found =
-            find_nvram_for_rom("rom1", &vpx_path, Some(&PathBuf::from("./")), None);
+        let found = find_nvram_for_rom("rom1", &vpx_path, Some(&PathBuf::from("./")), None);
         assert_eq!(found, Some(expected));
     }
 


### PR DESCRIPTION
## Summary

- Adds `vpxtool nvram show <PATH>` to resolve a PinMAME nvram file to JSON, mirroring the frontend's "NVRAM > Show" action.
- `PATH` accepts a `.vpx` (rom name extracted, `.nv` located via configured / `<vpx_parent>/pinmame` / global pinmame folders), a `.nv` (resolved directly), or a rom `.zip` (sibling `../nvram/<stem>.nv`).
- Exit code 1 with a clear message for non-PinMAME tables, missing nvram, or unsupported nvram maps.

Closes #706