### PR TITLE
feat(cli): add scores show for PinMAME tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,9 +1548,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pinmame-nvram"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6098b925391025952a9168cf4c1133ed0c24b0224c158ab24b3bb499a9cc53"
+checksum = "070ca9890bf30907213af31834ceaaa50d08933bcd95fa094e20512f04949f03"
 dependencies = [
  "brotli",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ vpin = { version = "0.26.1" }
 directb2s = "0.1.1"
 
 edit = "0.1.5"
-pinmame-nvram = "0.4.8"
+pinmame-nvram = "0.4.10"
 image = "0.25.10"
 
 #see https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,6 +110,9 @@ const CMD_DIPSWITCHES_SHOW: &str = "show";
 const CMD_NVRAM: &str = "nvram";
 const CMD_NVRAM_SHOW: &str = "show";
 
+const CMD_SCORES: &str = "scores";
+const CMD_SCORES_SHOW: &str = "show";
+
 const CMD_ROMNAME: &str = "romname";
 
 const CMD_EXPORT: &str = "export";
@@ -780,6 +783,10 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             Some((CMD_NVRAM_SHOW, sub_matches)) => handle_nvram_show(sub_matches),
             _ => unreachable!(),
         },
+        Some((CMD_SCORES, sub_matches)) => match sub_matches.subcommand() {
+            Some((CMD_SCORES_SHOW, sub_matches)) => handle_scores_show(sub_matches),
+            _ => unreachable!(),
+        },
         Some((CMD_EXPORT, sub_matches)) => match sub_matches.subcommand() {
             Some((CMD_EXPORT_OBJ, sub_matches)) => handle_export_obj(sub_matches),
             Some((CMD_EXPORT_GLTF, sub_matches)) => handle_export_gltf(sub_matches),
@@ -1294,6 +1301,37 @@ fn build_command() -> Command {
                 ),
         )
         .subcommand(
+            Command::new(CMD_SCORES)
+                .subcommand_required(true)
+                .about("Table high-score related commands")
+                .subcommand(
+                    Command::new(CMD_SCORES_SHOW)
+                        .about("Show high scores for a table")
+                        .long_about(
+                            "Show the high-score entries stored for a PinMAME-based table. \
+                             Walks the high_scores, mode_champions and more_mode_champions \
+                             arrays produced by the pinmame-nvram maps. PATH accepts a .vpx, \
+                             a .nv, or a rom .zip exactly like `nvram show`. PinMAME only \
+                             for now; rom-less tables that store scores in VPReg.ini are a \
+                             follow-up.\n\
+                             \n\
+                             Default format is an aligned LABEL / INITIALS / SCORE table \
+                             with comma-grouped scores. `--format tsv` emits tab-separated \
+                             rows with raw integer scores for scripting (label and initials \
+                             can contain spaces, so a tab-delimited format is the reliable \
+                             way to split columns).",
+                        )
+                        .arg(arg!(<PATH> "Path to a .vpx, .nv, or rom .zip file").required(true))
+                        .arg(
+                            Arg::new("FORMAT")
+                                .long("format")
+                                .value_parser(["table", "tsv"])
+                                .default_value("table")
+                                .help("Output format: 'table' (aligned, default) or 'tsv' (tab-separated, raw scores)"),
+                        ),
+                ),
+        )
+        .subcommand(
             Command::new(CMD_ROMNAME)
                 .about("Prints the PinMAME ROM name from a vpx file")
                 .long_about("Extracts the PinMAME ROM name from a vpx file by searching for specific patterns in the table script. If the table is not PinMAME based, no output is produced.")
@@ -1633,34 +1671,61 @@ fn handle_export_vpxz(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
-    let path = sub_matches
-        .get_one::<String>("PATH")
-        .map(|s| s.as_str())
-        .unwrap_or_default();
-    let expanded_path = path_exists(path)?;
+/// Resolve `path` to an nvram file. Accepts:
+/// * a `.nv` file directly,
+/// * a rom `.zip` (looks for `../nvram/<stem>.nv` next to it), or
+/// * a `.vpx` (reads the rom name from the script and searches the configured
+///   / global pinmame folders).
+///
+/// Returns a CLI-friendly error path on the failure cases so callers can just
+/// `?` into the rest of their handler.
+enum NvramResolveError {
+    NotPinmame(PathBuf),
+    NoNvramFor(PathBuf),
+    NoNvramNextToZip(PathBuf),
+    InvalidZipStem(PathBuf),
+    UnsupportedExtension(PathBuf),
+}
 
+impl NvramResolveError {
+    fn fail(self) -> io::Result<ExitCode> {
+        match self {
+            NvramResolveError::NotPinmame(p) => {
+                fail(format!("Table {} is not PinMAME-based", p.display()))
+            }
+            NvramResolveError::NoNvramFor(p) => fail(format!(
+                "No nvram file found for {} - try launching the table once",
+                p.display()
+            )),
+            NvramResolveError::NoNvramNextToZip(p) => fail(format!(
+                "No nvram file found next to rom zip {}",
+                p.display()
+            )),
+            NvramResolveError::InvalidZipStem(p) => {
+                fail(format!("rom zip has no usable file stem: {}", p.display()))
+            }
+            NvramResolveError::UnsupportedExtension(p) => fail(format!(
+                "Unsupported file type: {} (expected .vpx, .nv, or rom .zip)",
+                p.display()
+            )),
+        }
+    }
+}
+
+fn resolve_nvram_path(expanded_path: &Path) -> io::Result<Result<PathBuf, NvramResolveError>> {
     let nvram_path = match expanded_path
         .extension()
         .and_then(OsStr::to_str)
         .map(str::to_ascii_lowercase)
         .as_deref()
     {
-        Some("nv") => expanded_path.clone(),
+        Some("nv") => expanded_path.to_path_buf(),
         Some("zip") => {
-            // Treat as a rom zip: nvram lives at ../nvram/<stem>.nv.
-            let stem = expanded_path
-                .file_stem()
-                .and_then(OsStr::to_str)
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "rom zip has no usable file stem: {}",
-                            expanded_path.display()
-                        ),
-                    )
-                })?;
+            let Some(stem) = expanded_path.file_stem().and_then(OsStr::to_str) else {
+                return Ok(Err(NvramResolveError::InvalidZipStem(
+                    expanded_path.to_path_buf(),
+                )));
+            };
             let candidate = expanded_path
                 .parent()
                 .and_then(Path::parent)
@@ -1668,44 +1733,54 @@ fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             match candidate.filter(|p| p.is_file()) {
                 Some(p) => p,
                 None => {
-                    return fail(format!(
-                        "No nvram file found next to rom zip {}",
-                        expanded_path.display()
-                    ));
+                    return Ok(Err(NvramResolveError::NoNvramNextToZip(
+                        expanded_path.to_path_buf(),
+                    )));
                 }
             }
         }
         Some("vpx") => {
-            if indexer::get_romname_from_vpx(&expanded_path)?.is_none() {
-                return fail(format!(
-                    "Table {} is not PinMAME-based",
-                    expanded_path.display()
-                ));
+            if indexer::get_romname_from_vpx(expanded_path)?.is_none() {
+                return Ok(Err(NvramResolveError::NotPinmame(
+                    expanded_path.to_path_buf(),
+                )));
             }
             let loaded_config = config::load_config()?;
             let config = loaded_config.as_ref().map(|c| &c.1);
             let configured = config.and_then(|c| c.configured_pinmame_folder());
             let global = config.map(|c| c.global_pinmame_folder());
             match indexer::find_nvram_for_vpx(
-                &expanded_path,
+                expanded_path,
                 configured.as_deref(),
                 global.as_deref(),
             )? {
                 Some(p) => p,
                 None => {
-                    return fail(format!(
-                        "No nvram file found for {} - try launching the table once",
-                        expanded_path.display()
-                    ));
+                    return Ok(Err(NvramResolveError::NoNvramFor(
+                        expanded_path.to_path_buf(),
+                    )));
                 }
             }
         }
         _ => {
-            return fail(format!(
-                "Unsupported file type: {} (expected .vpx, .nv, or rom .zip)",
-                expanded_path.display()
-            ));
+            return Ok(Err(NvramResolveError::UnsupportedExtension(
+                expanded_path.to_path_buf(),
+            )));
         }
+    };
+    Ok(Ok(nvram_path))
+}
+
+fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
+    let path = sub_matches
+        .get_one::<String>("PATH")
+        .map(|s| s.as_str())
+        .unwrap_or_default();
+    let expanded_path = path_exists(path)?;
+
+    let nvram_path = match resolve_nvram_path(&expanded_path)? {
+        Ok(p) => p,
+        Err(e) => return e.fail(),
     };
 
     match pinmame_nvram::resolve::resolve(&nvram_path) {
@@ -1721,6 +1796,66 @@ fn handle_nvram_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             nvram_path.display()
         )),
     }
+}
+
+fn handle_scores_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
+    let path = sub_matches
+        .get_one::<String>("PATH")
+        .map(|s| s.as_str())
+        .unwrap_or_default();
+    let format = sub_matches
+        .get_one::<String>("FORMAT")
+        .map(|s| s.as_str())
+        .unwrap_or("table");
+    let expanded_path = path_exists(path)?;
+
+    let nvram_path = match resolve_nvram_path(&expanded_path)? {
+        Ok(p) => p,
+        Err(e) => return e.fail(),
+    };
+
+    let resolved = match pinmame_nvram::resolve::resolve(&nvram_path) {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return fail(format!("No pinmame-nvram map for {}", nvram_path.display()));
+        }
+        Err(e) => {
+            return fail(format!(
+                "Failed to resolve nvram {}: {e}",
+                nvram_path.display()
+            ));
+        }
+    };
+
+    let mut rows = crate::scores::extract_rows(&resolved);
+    match format {
+        "tsv" => {
+            // Header + raw rows, tab-separated. Scores stay as raw integers
+            // so scripts can `awk -F$'\t' '$3>=1000000'` directly; the
+            // trailing UNITS column lets scripts that care format time-like
+            // scores themselves.
+            crate::println!("{}", crate::scores::HEADERS.join("\t"))?;
+            for row in &rows {
+                crate::println!("{}", row.join("\t"))?;
+            }
+        }
+        _ => {
+            // Human view: drop the trailing UNITS column after using it to
+            // format the SCORE column (e.g. seconds -> mm:ss).
+            crate::scores::pretty_score_column(&mut rows);
+            let visible_headers = ["LABEL", "INITIALS", "SCORE"];
+            let aligns = [ColAlign::Left, ColAlign::Left, ColAlign::Right];
+            let visible_rows: Vec<Vec<String>> = rows
+                .into_iter()
+                .map(|mut r| {
+                    r.truncate(3);
+                    r
+                })
+                .collect();
+            print_aligned_table(&visible_headers, &aligns, &visible_rows)?;
+        }
+    }
+    Ok(ExitCode::SUCCESS)
 }
 
 /// Right- vs left-aligned column. The last column is printed without trailing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod indexer;
 
 pub mod cli;
 mod colorful_theme_patched;
+pub mod scores;
 pub mod vpinball_config;
 pub mod vpxz;
 

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -1,0 +1,357 @@
+//! Extract human-readable score rows from a resolved pinmame-nvram JSON value.
+//!
+//! The pinmame-nvram crate produces a `serde_json::Value` with score-bearing
+//! arrays (`high_scores`, `mode_champions`, `more_mode_champions`). This
+//! module turns those into a flat list of `(label, initials, score, units)`
+//! rows, applying the same "drop empty slots" filter PINemHi does so output
+//! line counts match.
+//!
+//! Scores come out **raw** (no thousands grouping, no units-aware formatting)
+//! so callers emitting machine-friendly formats (TSV, JSON) can use them as-is.
+//! Use [`pretty_score_column`] to apply comma grouping and unit-based
+//! formatting for the aligned-table human view.
+
+use serde_json::Value;
+
+const SCORE_ARRAYS: &[&str] = &["high_scores", "mode_champions", "more_mode_champions"];
+
+/// Numeric value keys we accept on a score entry, in priority order. Maps for
+/// regular high-scores use `score`; mode-champion maps use `counter` and
+/// occasionally `nth time`.
+const NUMERIC_KEYS: &[&str] = &["score", "counter", "nth time"];
+
+/// Column indices for rows produced by [`extract_rows`].
+pub const COL_LABEL: usize = 0;
+pub const COL_INITIALS: usize = 1;
+pub const COL_SCORE: usize = 2;
+pub const COL_UNITS: usize = 3;
+
+/// Header labels matching the columns above. TSV output emits all four; the
+/// aligned table emits the first three.
+pub const HEADERS: [&str; 4] = ["LABEL", "INITIALS", "SCORE", "UNITS"];
+
+/// Extract score rows.
+///
+/// Each row has four columns: `LABEL`, `INITIALS`, `SCORE` (raw, no thousands
+/// grouping, no unit-based formatting), and `UNITS` (empty string when the
+/// map has no `units` annotation). Entries whose numeric value is zero
+/// (cleared slots, e.g. Medieval Madness's empty King-of-the-Realm
+/// positions) are dropped to match PINemHi's "no entry recorded" behavior.
+pub fn extract_rows(resolved: &Value) -> Vec<Vec<String>> {
+    let mut rows = Vec::new();
+    for key in SCORE_ARRAYS {
+        let Some(entries) = resolved.get(*key).and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for entry in entries {
+            if let Some(row) = score_row_from_entry(entry) {
+                rows.push(row);
+            }
+        }
+    }
+    rows
+}
+
+/// Convert one entry of a score array into a `[label, initials, score, units]`
+/// row, or `None` if it is an empty / cleared slot. The `score` column is the
+/// raw numeric value (or pre-formatted string from the map) without thousands
+/// grouping; the `units` column is the map's `units` annotation (e.g.
+/// `"seconds"`) or an empty string. Callers needing a human view should pass
+/// the rows through [`pretty_score_column`].
+fn score_row_from_entry(entry: &Value) -> Option<Vec<String>> {
+    let label = entry.get("label").and_then(|v| v.as_str()).unwrap_or("");
+    // Some maps (e.g. Stern Whitestar's LotR) reserve a 10-char initials
+    // field for what's typically a 3-char value, padding the rest with
+    // spaces. Trim that trailing padding so TSV output is clean and table
+    // alignment is driven by the renderer, not by the map's raw width.
+    let initials = entry
+        .get("initials")
+        .and_then(|v| v.get("value"))
+        .and_then(|v| v.as_str())
+        .map(str::trim_end)
+        .unwrap_or("");
+    // Locate the score-bearing object (e.g. {"value": 600, "units": "seconds"})
+    // so we can pick both the numeric value and the units annotation from it.
+    let score_obj = NUMERIC_KEYS.iter().find_map(|k| entry.get(*k));
+    let numeric_value = score_obj.and_then(|o| o.get("value"));
+    let units = score_obj
+        .and_then(|o| o.get("units"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let score_str = match numeric_value {
+        Some(Value::Number(n)) => {
+            // Cleared / never-set slots get reported as zero by the maps;
+            // PINemHi suppresses them, so we do too. Keep non-zero numbers,
+            // including legitimately-low ones (a "world record" of 100 is
+            // still a recorded score).
+            if number_is_zero(n) {
+                return None;
+            }
+            n.to_string()
+        }
+        Some(Value::String(s)) => s.clone(),
+        _ => String::new(),
+    };
+
+    // Drop entries that produced no displayable content at all.
+    if label.is_empty() && initials.is_empty() && score_str.is_empty() {
+        return None;
+    }
+    Some(vec![
+        label.to_string(),
+        initials.to_string(),
+        score_str,
+        units.to_string(),
+    ])
+}
+
+/// Render the SCORE column (`COL_SCORE`) in place for the aligned-table human
+/// view, using the UNITS column (`COL_UNITS`) as a formatting hint:
+///
+/// * `units: "seconds"` -> `mm:ss` (or `h:mm:ss` past an hour)
+/// * everything else -> thousands grouping for integers, pass-through for
+///   non-integer strings (already-formatted times, etc.)
+pub fn pretty_score_column(rows: &mut [Vec<String>]) {
+    for row in rows {
+        if row.len() <= COL_SCORE {
+            continue;
+        }
+        let units = row.get(COL_UNITS).cloned().unwrap_or_default();
+        let score = &mut row[COL_SCORE];
+        match units.as_str() {
+            "seconds" => {
+                if let Ok(n) = score.parse::<u64>() {
+                    *score = format_seconds_as_time(n);
+                }
+            }
+            _ => {
+                if let Ok(n) = score.parse::<u64>() {
+                    *score = group_thousands_u64(n);
+                } else if let Ok(n) = score.parse::<i64>() {
+                    let abs = group_thousands_u64(n.unsigned_abs());
+                    *score = if n < 0 { format!("-{abs}") } else { abs };
+                }
+                // Non-integer string (pre-formatted time etc.) - leave alone.
+            }
+        }
+    }
+}
+
+/// Format an integer number of seconds as `mm:ss`, or `h:mm:ss` once it
+/// reaches an hour. Used for `units: "seconds"` scores (LotR's Destroy Ring
+/// Champion is the canonical example - 600 -> `10:00`).
+fn format_seconds_as_time(total: u64) -> String {
+    let hours = total / 3600;
+    let minutes = (total % 3600) / 60;
+    let seconds = total % 60;
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
+    }
+}
+
+fn number_is_zero(n: &serde_json::Number) -> bool {
+    if let Some(u) = n.as_u64() {
+        return u == 0;
+    }
+    if let Some(i) = n.as_i64() {
+        return i == 0;
+    }
+    if let Some(f) = n.as_f64() {
+        return f == 0.0;
+    }
+    false
+}
+
+fn group_thousands_u64(mut n: u64) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    let mut out = String::new();
+    let mut group_digits = 0;
+    while n > 0 {
+        if group_digits == 3 {
+            out.push(',');
+            group_digits = 0;
+        }
+        out.push(char::from_digit((n % 10) as u32, 10).unwrap());
+        n /= 10;
+        group_digits += 1;
+    }
+    out.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_high_scores_in_array_order_with_raw_numeric_scores() {
+        let resolved = json!({
+            "high_scores": [
+                {"label": "Grand Champion", "initials": {"value": "JBJ"}, "score": {"value": 180000000}},
+                {"label": "First Place",    "initials": {"value": "DRF"}, "score": {"value": 165000000}},
+            ]
+        });
+        // extract_rows returns raw scores (no commas) and an empty units
+        // column when the map doesn't annotate one. Machine consumers can
+        // use the values verbatim; pretty_score_column adds the grouping
+        // for the aligned human view.
+        assert_eq!(
+            extract_rows(&resolved),
+            vec![
+                vec![
+                    "Grand Champion".to_string(),
+                    "JBJ".to_string(),
+                    "180000000".to_string(),
+                    "".to_string(),
+                ],
+                vec![
+                    "First Place".to_string(),
+                    "DRF".to_string(),
+                    "165000000".to_string(),
+                    "".to_string(),
+                ],
+            ]
+        );
+    }
+
+    #[test]
+    fn extracts_units_when_map_provides_them() {
+        // LotR Destroy Ring Champion is annotated `units: "seconds"` by
+        // pinmame-nvram >=0.4.9; the row must surface it so the table
+        // renderer can format the score as a time.
+        let resolved = json!({
+            "mode_champions": [
+                {"label": "Destroy Ring Champion", "initials": {"value": "EYE"},
+                 "score": {"value": 600, "units": "seconds"}},
+            ]
+        });
+        let rows = extract_rows(&resolved);
+        assert_eq!(rows[0][COL_SCORE], "600");
+        assert_eq!(rows[0][COL_UNITS], "seconds");
+    }
+
+    #[test]
+    fn pretty_score_column_groups_integer_score_thousands() {
+        let mut rows = vec![
+            vec!["A".into(), "AAA".into(), "180000000".into(), "".into()],
+            vec!["B".into(), "BBB".into(), "7".into(), "".into()],
+        ];
+        pretty_score_column(&mut rows);
+        assert_eq!(rows[0][COL_SCORE], "180,000,000");
+        assert_eq!(rows[1][COL_SCORE], "7");
+    }
+
+    #[test]
+    fn pretty_score_column_renders_seconds_as_time() {
+        // LotR Destroy Ring Champion: 600 seconds -> 10:00.
+        let mut rows = vec![vec![
+            "Destroy Ring Champion".into(),
+            "EYE".into(),
+            "600".into(),
+            "seconds".into(),
+        ]];
+        pretty_score_column(&mut rows);
+        assert_eq!(rows[0][COL_SCORE], "10:00");
+    }
+
+    #[test]
+    fn pretty_score_column_renders_long_seconds_as_h_mm_ss() {
+        // 3 hours 45 minutes 7 seconds.
+        let mut rows = vec![vec![
+            "Marathon".into(),
+            "AAA".into(),
+            "13507".into(),
+            "seconds".into(),
+        ]];
+        pretty_score_column(&mut rows);
+        assert_eq!(rows[0][COL_SCORE], "3:45:07");
+    }
+
+    #[test]
+    fn pretty_score_column_leaves_string_scores_alone() {
+        // Pre-formatted scores (timer strings written into the map as a
+        // string value, etc.) must pass through unchanged.
+        let mut rows = vec![vec!["A".into(), "AAA".into(), "10:00.00".into(), "".into()]];
+        pretty_score_column(&mut rows);
+        assert_eq!(rows[0][COL_SCORE], "10:00.00");
+    }
+
+    #[test]
+    fn appends_mode_champions_after_high_scores() {
+        let resolved = json!({
+            "high_scores": [
+                {"label": "GC", "initials": {"value": "AAA"}, "score": {"value": 1000}},
+            ],
+            "mode_champions": [
+                {"label": "Castle Champion", "initials": {"value": "JCY"}, "score": {"value": 6}},
+            ],
+        });
+        let rows = extract_rows(&resolved);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0][0], "GC");
+        assert_eq!(rows[1][0], "Castle Champion");
+    }
+
+    #[test]
+    fn drops_entries_with_zero_numeric_value() {
+        // Mirrors MM's unset King-of-the-Realm slots: initials still set
+        // from a previous wipe, counter zero. PINemHi suppresses these; we do too.
+        let resolved = json!({
+            "mode_champions": [
+                {"label": "King #1", "initials": {"value": "KOP"}, "counter": {"value": 1}},
+                {"label": "King #2", "initials": {"value": "KOP"}, "counter": {"value": 0}},
+                {"label": "King #3", "initials": {"value": "KOP"}, "counter": {"value": 0}},
+            ]
+        });
+        let rows = extract_rows(&resolved);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], "King #1");
+    }
+
+    #[test]
+    fn falls_back_through_score_then_counter_then_nth_time() {
+        // The `nth time` key (with a space) is real - shows up on
+        // King-of-the-Realm-style entries alongside `counter`.
+        let resolved = json!({
+            "mode_champions": [
+                {"label": "Old style", "initials": {"value": "ABC"}, "nth time": {"value": 7}},
+            ]
+        });
+        let rows = extract_rows(&resolved);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][2], "7");
+    }
+
+    #[test]
+    fn accepts_string_score_values() {
+        // Some maps express counters as already-formatted strings (e.g.
+        // "10:00.00" for a destroy-the-ring timer). Pass them through.
+        let resolved = json!({
+            "mode_champions": [
+                {"label": "Destroy Ring Champion", "initials": {"value": "EYE"}, "score": {"value": "10:00.00"}},
+            ]
+        });
+        let rows = extract_rows(&resolved);
+        assert_eq!(rows[0][2], "10:00.00");
+    }
+
+    #[test]
+    fn returns_empty_when_resolved_has_no_score_arrays() {
+        let resolved = json!({"audits": [], "game_state": {}});
+        assert!(extract_rows(&resolved).is_empty());
+    }
+
+    #[test]
+    fn group_thousands_handles_zero_and_small() {
+        assert_eq!(group_thousands_u64(0), "0");
+        assert_eq!(group_thousands_u64(7), "7");
+        assert_eq!(group_thousands_u64(999), "999");
+        assert_eq!(group_thousands_u64(1000), "1,000");
+    }
+}


### PR DESCRIPTION
## Summary

\`vpxtool scores show <PATH>\` renders the high-score entries stored for a PinMAME-based table as aligned \`LABEL, INITIALS, SCORE\` columns. PATH accepts a \`.vpx\`, \`.nv\`, or rom \`.zip\` - identical resolution to \`nvram show\` (refactored into a shared \`resolve_nvram_path\` helper).

Score extraction lives in a new \`scores\` module that walks the pinmame-nvram crate's resolved JSON (\`high_scores\`, \`mode_champions\`, \`more_mode_champions\` arrays), drops cleared slots with a zero numeric value to match PINemHi's \"no entry recorded\" behavior, and groups thousands in numeric scores.

Example:

\`\`\`
$ vpxtool scores show 'Medieval Madness (Williams 1997)/pinmame/nvram/mm_109c.nv'
LABEL                 INITIALS  SCORE
Grand Champion        SLL       52,000,000
First Place           BRE       44,000,000
Second Place          LFS       40,000,000
Third Place           ZAP       36,000,000
Fourth Place          RCF       32,000,000
Castle Champion       JCY       6
Joust Champion        DWF       5
Catapult Champion     ASR       5
Peasant Champion      BCM       5
Damsel Champion       DJW       5
Troll Champion        JCD       20
Madness Champion      KOZ       20,000,000
King of the Realm #1  KOP       1
\`\`\`

## PINemHi spot-check

PINemHi 3.6.8 run against the same six nvrams via Wine for comparison:

| table | ours | pinemhi | notes |
|---|---|---|---|
| CFTBL | 5 | 5 | match |
| Medieval Madness | 13 | 13 | match |
| Apollo 13 | 6 | 6 | match |
| BTTF | 6 | 6 | match |
| LotR | 6 | 6 | Destroy Ring Champion: ours shows raw \`600\`, PINemHi shows \`10:00.00\`. Same data, different formatter. Entry count matches. |
| WHO dunnit | 6 | 7 | PINemHi knows of a \"Midnight Champ\" the pinmame-nvram map doesn't currently expose - upstream gap, not a vpxtool one |

## Scope

PinMAME only for now. Rom-less tables that persist to \`VPReg.ini\` (Matrix, Guardians, etc.) and tables that roll their own \`.txt\` formats (e.g. \"Black's Highscore routines\" - found in \`Carnaval no Rio\`, \`8 Ball Williams 1966\` and probably others) are deliberately out of scope and will land as follow-up PRs, eventually driven by a community-editable spec file rather than per-table code (no \`huge if/else\`).

## Test plan

- [x] \`cargo test\` (93 pass, 8 new unit tests covering the rows extractor)
- [x] \`cargo clippy --all-targets\` clean
- [x] \`cargo fmt\` clean
- [x] Manual: spot-checked six representative tables against PINemHi 3.6.8 via Wine