### PR TITLE
feat(cli): locale-aware thousands separator and aligned columns in scores show

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -242,10 +242,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -382,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfb"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +499,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -766,7 +814,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -823,7 +871,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -957,7 +1005,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1167,7 +1215,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1221,7 +1269,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1269,6 +1317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,12 +1351,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -1442,7 +1506,33 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "encoding_rs",
+ "itoa",
+ "lazy_static",
+ "libc",
+ "num-format-windows",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
+name = "num-format-windows"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1e07f67225c1eb911d16c2f72492669c1fb08212dbfaa1f6cfbeb119152cfa"
+dependencies = [
+ "bindgen",
 ]
 
 [[package]]
@@ -1537,8 +1627,14 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
@@ -1565,7 +1661,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1613,7 +1709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1633,7 +1729,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -1654,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1828,7 +1924,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1894,12 +1990,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1912,7 +2014,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
@@ -1970,7 +2072,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1995,7 +2097,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2060,6 +2162,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2132,7 +2245,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2280,7 +2393,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2417,6 +2530,7 @@ dependencies = [
  "jojodiff",
  "jwalk",
  "log",
+ "num-format",
  "pinmame-nvram",
  "pretty_assertions",
  "rand 0.10.1",
@@ -2494,7 +2608,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2516,7 +2630,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2558,7 +2672,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
@@ -2621,6 +2735,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wild"
@@ -2867,7 +2987,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2880,7 +3000,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2896,7 +3016,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2908,7 +3028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.9.0",
  "indexmap",
  "log",
  "serde",
@@ -2967,7 +3087,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ directb2s = "0.1.1"
 edit = "0.1.5"
 pinmame-nvram = "0.4.10"
 image = "0.25.10"
+num-format = "0.4.4"
 
 #see https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
@@ -54,6 +55,15 @@ jwalk = "0.8.1"
 rayon = "1.12.0"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 globset = "0.4.18"
+
+# num-format's `with-system-locale` feature pulls a winapi path
+# (`winapi::um::errhandlingapi`) without declaring the required winapi
+# feature flag, breaking the Windows build. Upstream:
+# https://github.com/bcmyers/num-format/issues/43 (open since 2023).
+# Enable the feature only off-Windows; Windows falls back to a fixed
+# Locale::en in the call sites.
+[target.'cfg(not(windows))'.dependencies]
+num-format = { version = "0.4.4", features = ["with-system-locale"] }
 
 [dev-dependencies]
 testdir = "0.9.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1832,7 +1832,7 @@ fn handle_scores_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             // Header + raw rows, tab-separated. Scores stay as raw integers
             // so scripts can `awk -F$'\t' '$3>=1000000'` directly; the
             // trailing UNITS column lets scripts that care format time-like
-            // scores themselves.
+            // scores themselves. Locale-independent by design.
             let rows = crate::scores::extract_rows(&resolved);
             crate::println!("{}", crate::scores::HEADERS.join("\t"))?;
             for row in &rows {
@@ -1844,14 +1844,31 @@ fn handle_scores_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             // GRAND CHAMPION block when present, one HIGH SCORES block for
             // ranked entries, one section per mode champion.
             let sections = crate::scores::extract_sections(&resolved);
-            let rendered = crate::scores::render_pinemhi(&sections);
+            // Branch on the locale type rather than using a `&dyn Format` -
+            // num-format's ToFormattedString requires Sized. Windows lacks
+            // SystemLocale (see Cargo.toml note) so it always uses Locale::en.
+            #[cfg(not(windows))]
+            let rendered = if let Some(sys) = readable_system_locale() {
+                crate::scores::render_pinemhi(&sections, &sys)
+            } else {
+                crate::scores::render_pinemhi(&sections, &num_format::Locale::en)
+            };
+            #[cfg(windows)]
+            let rendered = crate::scores::render_pinemhi(&sections, &num_format::Locale::en);
             crate::print!("{}", rendered)?;
         }
         _ => {
             // Human table view: drop the trailing UNITS column after using
             // it to format the SCORE column (e.g. seconds -> mm:ss).
             let mut rows = crate::scores::extract_rows(&resolved);
-            crate::scores::pretty_score_column(&mut rows);
+            #[cfg(not(windows))]
+            if let Some(sys) = readable_system_locale() {
+                crate::scores::pretty_score_column(&mut rows, &sys);
+            } else {
+                crate::scores::pretty_score_column(&mut rows, &num_format::Locale::en);
+            }
+            #[cfg(windows)]
+            crate::scores::pretty_score_column(&mut rows, &num_format::Locale::en);
             let visible_headers = ["LABEL", "INITIALS", "SCORE"];
             let aligns = [ColAlign::Left, ColAlign::Left, ColAlign::Right];
             let visible_rows: Vec<Vec<String>> = rows
@@ -1865,6 +1882,25 @@ fn handle_scores_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
         }
     }
     Ok(ExitCode::SUCCESS)
+}
+
+/// Read the user's `LC_ALL` / `LANG` / `LC_NUMERIC` to pick a thousands
+/// separator, but **fall back to `Locale::en` (comma) when the system locale
+/// has no separator at all** - the POSIX `C` / `POSIX` locales specify
+/// `thousands_sep=""`, which would render `52000000` instead of `52,000,000`.
+/// PINemHi makes the same readability-over-strict-POSIX call, so we match.
+///
+/// Windows-only note: `num-format`'s `with-system-locale` Windows backend
+/// fails to build (https://github.com/bcmyers/num-format/issues/43), so
+/// this function is not compiled there; the call sites fall back to
+/// `Locale::en` directly.
+#[cfg(not(windows))]
+fn readable_system_locale() -> Option<num_format::SystemLocale> {
+    let sys = num_format::SystemLocale::default().ok()?;
+    if sys.separator().is_empty() {
+        return None;
+    }
+    Some(sys)
 }
 
 /// Right- vs left-aligned column. The last column is printed without trailing

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -11,6 +11,7 @@
 //! Use [`pretty_score_column`] to apply comma grouping and unit-based
 //! formatting for the aligned-table human view.
 
+use num_format::{Format, ToFormattedString};
 use serde_json::Value;
 
 /// Numeric value keys we accept on a score entry, in priority order. Maps for
@@ -167,8 +168,20 @@ fn is_ranked_label(label: &str) -> bool {
 /// own line, then rows below (ranked sections prefix each row with `N.`,
 /// unranked single-entry sections drop the rank). Empty initials collapse to
 /// score-only. Section bodies use the [`pretty_score_column`] formatting
-/// (thousands grouping, seconds-to-time).
-pub fn render_pinemhi(sections: &[Section]) -> String {
+/// (thousands grouping per `locale`, seconds-to-time).
+///
+/// Columns are padded per-section so the rank, initials, and score columns
+/// line up: rank is left-padded to the largest rank's width, initials are
+/// left-padded to the widest initials in the section, scores are
+/// right-padded so digits align. Widths use char count (not byte count) so
+/// locales whose thousands separator is multi-byte (e.g. fr_FR's U+202F)
+/// still align.
+///
+/// `locale` is generic over `num_format::Format` rather than `&dyn Format`
+/// because the underlying `ToFormattedString::to_formatted_string` requires
+/// `Sized`. Callers that want runtime locale selection should branch on the
+/// chosen locale type and dispatch into a monomorphized copy per arm.
+pub fn render_pinemhi<F: Format>(sections: &[Section], locale: &F) -> String {
     let mut out = String::new();
     for (idx, section) in sections.iter().enumerate() {
         if idx > 0 {
@@ -176,30 +189,49 @@ pub fn render_pinemhi(sections: &[Section]) -> String {
         }
         out.push_str(&section.header);
         out.push('\n');
-        // Apply table-style score formatting (commas / mm:ss) without
-        // touching the raw row data.
+        // Apply table-style score formatting (locale-aware grouping / mm:ss)
+        // without touching the raw row data.
         let mut formatted = section.rows.clone();
-        pretty_score_column(&mut formatted);
+        pretty_score_column(&mut formatted, locale);
+
+        let initials_w = formatted
+            .iter()
+            .map(|r| r.get(COL_INITIALS).map_or(0, |s| s.chars().count()))
+            .max()
+            .unwrap_or(0);
+        let score_w = formatted
+            .iter()
+            .map(|r| r.get(COL_SCORE).map_or(0, |s| s.chars().count()))
+            .max()
+            .unwrap_or(0);
+        // Width of the largest rank label ("10." -> 3) so two-digit ranks
+        // don't push the initials column out of alignment.
+        let rank_w = if section.ranked {
+            format!("{}.", formatted.len()).chars().count()
+        } else {
+            0
+        };
+
         for (i, row) in formatted.iter().enumerate() {
             let initials = row.get(COL_INITIALS).map(String::as_str).unwrap_or("");
             let score = row.get(COL_SCORE).map(String::as_str).unwrap_or("");
-            let line = if section.ranked {
-                let rank = i + 1;
-                match (initials, score) {
-                    ("", "") => format!("{rank}."),
-                    ("", s) => format!("{rank}. {s}"),
-                    (i_str, "") => format!("{rank}. {i_str}"),
-                    (i_str, s) => format!("{rank}. {i_str}  {s}"),
+            let mut line = String::new();
+            if section.ranked {
+                let rank = format!("{}.", i + 1);
+                line.push_str(&format!("{rank:<rank_w$} "));
+            }
+            if initials_w > 0 {
+                line.push_str(&format!("{initials:<initials_w$}"));
+                if score_w > 0 {
+                    line.push_str("  ");
                 }
-            } else {
-                match (initials, score) {
-                    ("", "") => String::new(),
-                    ("", s) => s.to_string(),
-                    (i_str, "") => i_str.to_string(),
-                    (i_str, s) => format!("{i_str}  {s}"),
-                }
-            };
-            out.push_str(&line);
+            }
+            if score_w > 0 {
+                line.push_str(&format!("{score:>score_w$}"));
+            }
+            // Drop trailing padding so rows missing a score/initials don't
+            // emit stray whitespace at end-of-line.
+            out.push_str(line.trim_end());
             out.push('\n');
         }
     }
@@ -264,9 +296,13 @@ fn score_row_from_entry(entry: &Value) -> Option<Vec<String>> {
 /// view, using the UNITS column (`COL_UNITS`) as a formatting hint:
 ///
 /// * `units: "seconds"` -> `mm:ss` (or `h:mm:ss` past an hour)
-/// * everything else -> thousands grouping for integers, pass-through for
-///   non-integer strings (already-formatted times, etc.)
-pub fn pretty_score_column(rows: &mut [Vec<String>]) {
+/// * everything else -> thousands grouping for integers (per `locale`),
+///   pass-through for non-integer strings (already-formatted times, etc.)
+///
+/// `locale` controls the thousands separator: pass a `num_format::Locale`
+/// (e.g. `Locale::en` for `1,234,567`) or a `SystemLocale` to follow the
+/// user's `LC_ALL`/`LANG`/`LC_NUMERIC` env at runtime.
+pub fn pretty_score_column<F: Format>(rows: &mut [Vec<String>], locale: &F) {
     for row in rows {
         if row.len() <= COL_SCORE {
             continue;
@@ -281,10 +317,9 @@ pub fn pretty_score_column(rows: &mut [Vec<String>]) {
             }
             _ => {
                 if let Ok(n) = score.parse::<u64>() {
-                    *score = group_thousands_u64(n);
+                    *score = n.to_formatted_string(locale);
                 } else if let Ok(n) = score.parse::<i64>() {
-                    let abs = group_thousands_u64(n.unsigned_abs());
-                    *score = if n < 0 { format!("-{abs}") } else { abs };
+                    *score = n.to_formatted_string(locale);
                 }
                 // Non-integer string (pre-formatted time etc.) - leave alone.
             }
@@ -319,29 +354,17 @@ fn number_is_zero(n: &serde_json::Number) -> bool {
     false
 }
 
-fn group_thousands_u64(mut n: u64) -> String {
-    if n == 0 {
-        return "0".to_string();
-    }
-    let mut out = String::new();
-    let mut group_digits = 0;
-    while n > 0 {
-        if group_digits == 3 {
-            out.push(',');
-            group_digits = 0;
-        }
-        out.push(char::from_digit((n % 10) as u32, 10).unwrap());
-        n /= 10;
-        group_digits += 1;
-    }
-    out.chars().rev().collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use num_format::Locale;
     use pretty_assertions::assert_eq;
     use serde_json::json;
+
+    /// Pinned locale for tests so output is reproducible regardless of the
+    /// developer's `LC_ALL` / `LC_NUMERIC` setting. Production callers
+    /// use `SystemLocale::default()` to honor the user's env.
+    const TEST_LOCALE: &Locale = &Locale::en;
 
     #[test]
     fn extracts_high_scores_in_array_order_with_raw_numeric_scores() {
@@ -396,7 +419,7 @@ mod tests {
             vec!["A".into(), "AAA".into(), "180000000".into(), "".into()],
             vec!["B".into(), "BBB".into(), "7".into(), "".into()],
         ];
-        pretty_score_column(&mut rows);
+        pretty_score_column(&mut rows, TEST_LOCALE);
         assert_eq!(rows[0][COL_SCORE], "180,000,000");
         assert_eq!(rows[1][COL_SCORE], "7");
     }
@@ -410,7 +433,7 @@ mod tests {
             "600".into(),
             "seconds".into(),
         ]];
-        pretty_score_column(&mut rows);
+        pretty_score_column(&mut rows, TEST_LOCALE);
         assert_eq!(rows[0][COL_SCORE], "10:00");
     }
 
@@ -423,7 +446,7 @@ mod tests {
             "13507".into(),
             "seconds".into(),
         ]];
-        pretty_score_column(&mut rows);
+        pretty_score_column(&mut rows, TEST_LOCALE);
         assert_eq!(rows[0][COL_SCORE], "3:45:07");
     }
 
@@ -432,7 +455,7 @@ mod tests {
         // Pre-formatted scores (timer strings written into the map as a
         // string value, etc.) must pass through unchanged.
         let mut rows = vec![vec!["A".into(), "AAA".into(), "10:00.00".into(), "".into()]];
-        pretty_score_column(&mut rows);
+        pretty_score_column(&mut rows, TEST_LOCALE);
         assert_eq!(rows[0][COL_SCORE], "10:00.00");
     }
 
@@ -502,11 +525,17 @@ mod tests {
     }
 
     #[test]
-    fn group_thousands_handles_zero_and_small() {
-        assert_eq!(group_thousands_u64(0), "0");
-        assert_eq!(group_thousands_u64(7), "7");
-        assert_eq!(group_thousands_u64(999), "999");
-        assert_eq!(group_thousands_u64(1000), "1,000");
+    fn pretty_score_column_uses_passed_locale_for_grouping_separator() {
+        // PINemHi honors LC_ALL/LANG for the thousands separator. We want
+        // the same behavior, threaded through the locale parameter rather
+        // than implicit global state.
+        let mut rows_en = vec![vec!["A".into(), "AAA".into(), "1234567".into(), "".into()]];
+        pretty_score_column(&mut rows_en, &Locale::en);
+        assert_eq!(rows_en[0][COL_SCORE], "1,234,567");
+
+        let mut rows_de = vec![vec!["A".into(), "AAA".into(), "1234567".into(), "".into()]];
+        pretty_score_column(&mut rows_de, &Locale::de);
+        assert_eq!(rows_de[0][COL_SCORE], "1.234.567");
     }
 
     #[test]
@@ -605,11 +634,56 @@ mod tests {
             ]
         });
         let sections = extract_sections(&resolved);
-        let rendered = render_pinemhi(&sections);
+        let rendered = render_pinemhi(&sections, TEST_LOCALE);
         assert_eq!(
             rendered,
             "GRAND CHAMPION\nSLL  52,000,000\n\nHIGH SCORES\n1. BRE  44,000,000\n"
         );
+    }
+
+    #[test]
+    fn render_pinemhi_aligns_score_column_when_initials_widths_differ() {
+        // Baywatch-style: most entries have 3-char initials but one is
+        // shorter. Score column must stay aligned vertically.
+        let resolved = json!({
+            "high_scores": [
+                {"label": "#1", "initials": {"value": "JEK"}, "score": {"value": 2_400_000_000_u64}},
+                {"label": "#2", "initials": {"value": "LON"}, "score": {"value": 2_100_000_000_u64}},
+                {"label": "#3", "initials": {"value": "NF"},  "score": {"value": 1_950_000_000_u64}},
+            ]
+        });
+        let sections = extract_sections(&resolved);
+        let rendered = render_pinemhi(&sections, TEST_LOCALE);
+        assert_eq!(
+            rendered,
+            "HIGH SCORES\n\
+             1. JEK  2,400,000,000\n\
+             2. LON  2,100,000,000\n\
+             3. NF   1,950,000,000\n"
+        );
+    }
+
+    #[test]
+    fn render_pinemhi_pads_rank_for_two_digit_ranks() {
+        // Sections with >=10 rows must pad single-digit ranks so the
+        // initials column doesn't jog left on rows 1-9.
+        let rows: Vec<_> = (1..=10)
+            .map(|i| {
+                serde_json::json!({
+                    "label": format!("#{i}"),
+                    "initials": {"value": "AAA"},
+                    "score": {"value": 1000 - i * 10},
+                })
+            })
+            .collect();
+        let resolved = serde_json::json!({ "high_scores": rows });
+        let sections = extract_sections(&resolved);
+        let rendered = render_pinemhi(&sections, TEST_LOCALE);
+        // Lines 1-9 prefix is "1.  ".."9.  " (rank padded to width 3);
+        // line 10 is "10. ".
+        assert!(rendered.contains("\n1.  AAA  990\n"));
+        assert!(rendered.contains("\n9.  AAA  910\n"));
+        assert!(rendered.contains("\n10. AAA  900\n"));
     }
 
     #[test]
@@ -621,7 +695,7 @@ mod tests {
             ]
         });
         let sections = extract_sections(&resolved);
-        let rendered = render_pinemhi(&sections);
+        let rendered = render_pinemhi(&sections, TEST_LOCALE);
         assert_eq!(rendered, "THE ROOF CHAMPION\nXAQ\n");
     }
 
@@ -634,7 +708,7 @@ mod tests {
             ]
         });
         let sections = extract_sections(&resolved);
-        let rendered = render_pinemhi(&sections);
+        let rendered = render_pinemhi(&sections, TEST_LOCALE);
         assert_eq!(rendered, "HIGH SCORE\n1,989,660\n");
     }
 }


### PR DESCRIPTION
## Summary
- `scores show` now honors `LC_ALL`/`LC_NUMERIC`/`LANG` for thousands grouping (falling back to `en` for POSIX `C` so output stays readable, matching PINemHi).
- `--format pinemhi` rows now pad rank, initials, and score columns per-section so the score column stays vertically aligned when initials widths differ.

## Test plan
- [x] `cargo test --lib scores`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Eyeballed `baywatch.nv` against Wine PINemHi in `en_US` and `de_DE`