### PR TITLE
feat(cli): scores show falls back to VPReg.ini for rom-less .vpx tables

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1308,12 +1308,12 @@ fn build_command() -> Command {
                     Command::new(CMD_SCORES_SHOW)
                         .about("Show high scores for a table")
                         .long_about(
-                            "Show the high-score entries stored for a PinMAME-based table. \
-                             Walks the high_scores, mode_champions and more_mode_champions \
-                             arrays produced by the pinmame-nvram maps. PATH accepts a .vpx, \
-                             a .nv, or a rom .zip exactly like `nvram show`. PinMAME only \
-                             for now; rom-less tables that store scores in VPReg.ini are a \
-                             follow-up.\n\
+                            "Show the high-score entries stored for a table. PATH accepts a \
+                             .vpx, a .nv, or a rom .zip exactly like `nvram show`. PinMAME \
+                             tables (.nv/.zip or .vpx with a ROM) are resolved through the \
+                             pinmame-nvram maps. For rom-less .vpx tables, VPReg.ini next to \
+                             the table (in `user/` first, then sibling) is probed using the \
+                             script's cGameName as the section key.\n\
                              \n\
                              Default format is an aligned LABEL / INITIALS / SCORE table \
                              with comma-grouped scores. `--format tsv` emits tab-separated \
@@ -1809,58 +1809,120 @@ fn handle_scores_show(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
         .unwrap_or("table");
     let expanded_path = path_exists(path)?;
 
-    let nvram_path = match resolve_nvram_path(&expanded_path)? {
-        Ok(p) => p,
-        Err(e) => return e.fail(),
+    // Resolve the input into a flat list of sections, trying PinMAME first
+    // and falling back to VPReg.ini for .vpx tables that are not PinMAME.
+    let sections: Vec<crate::scores::Section> = match resolve_nvram_path(&expanded_path)? {
+        Ok(nvram_path) => match pinmame_nvram::resolve::resolve(&nvram_path) {
+            Ok(Some(r)) => crate::scores::extract_sections(&r),
+            Ok(None) => {
+                return fail(format!("No pinmame-nvram map for {}", nvram_path.display()));
+            }
+            Err(e) => {
+                return fail(format!(
+                    "Failed to resolve nvram {}: {e}",
+                    nvram_path.display()
+                ));
+            }
+        },
+        Err(prior) => match try_vpreg_fallback(&expanded_path, &prior)? {
+            Some(sections) => sections,
+            None => return prior.fail(),
+        },
     };
 
-    let resolved = match pinmame_nvram::resolve::resolve(&nvram_path) {
-        Ok(Some(r)) => r,
-        Ok(None) => {
-            return fail(format!("No pinmame-nvram map for {}", nvram_path.display()));
-        }
-        Err(e) => {
-            return fail(format!(
-                "Failed to resolve nvram {}: {e}",
-                nvram_path.display()
-            ));
-        }
-    };
+    render_sections(&sections, format)
+}
 
+/// If `expanded_path` is a `.vpx` that PinMAME resolution couldn't handle,
+/// probe for a VPReg.ini next to it (in `user/` first, then sibling) and
+/// look up the `[<cGameName>]` section. Returns `Some(sections)` on success.
+/// Returns `Ok(None)` when the fallback isn't applicable (non-vpx input,
+/// non-fallthrough error, no `cGameName` in the script, or no matching
+/// VPReg.ini section anywhere) so the caller falls back to the original
+/// PinMAME error message.
+fn try_vpreg_fallback(
+    expanded_path: &Path,
+    prior_err: &NvramResolveError,
+) -> io::Result<Option<Vec<crate::scores::Section>>> {
+    let is_vpx = expanded_path
+        .extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|e| e.eq_ignore_ascii_case("vpx"));
+    let should_try = is_vpx
+        && matches!(
+            prior_err,
+            NvramResolveError::NotPinmame(_) | NvramResolveError::NoNvramFor(_)
+        );
+    if !should_try {
+        return Ok(None);
+    }
+    let Some(game_name) = indexer::get_gamename_from_vpx(expanded_path)? else {
+        return Ok(None);
+    };
+    let vpx_parent = expanded_path.parent().unwrap_or(Path::new("."));
+    // `user/` first because standalone vpinball writes there by default;
+    // sibling as a fallback for older layouts.
+    let candidates = [
+        vpx_parent.join("user").join("VPReg.ini"),
+        vpx_parent.join("VPReg.ini"),
+    ];
+    for candidate in &candidates {
+        if !candidate.is_file() {
+            continue;
+        }
+        match crate::scores::vpreg::read_sections(candidate, &game_name) {
+            Ok(sections) => return Ok(Some(sections)),
+            Err(crate::scores::vpreg::LookupError::SectionNotFound)
+            | Err(crate::scores::vpreg::LookupError::SectionHasNoScores) => continue,
+            Err(crate::scores::vpreg::LookupError::ParseFailed(msg)) => {
+                return Err(io::Error::other(format!(
+                    "Failed to parse {}: {msg}",
+                    candidate.display()
+                )));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Render a resolved `Vec<Section>` in the requested format. Common rendering
+/// path shared by every backend (PinMAME nvram, VPReg.ini, future GLF/Black's).
+fn render_sections(sections: &[crate::scores::Section], format: &str) -> io::Result<ExitCode> {
     match format {
         "tsv" => {
             // Header + raw rows, tab-separated. Scores stay as raw integers
             // so scripts can `awk -F$'\t' '$3>=1000000'` directly; the
             // trailing UNITS column lets scripts that care format time-like
             // scores themselves. Locale-independent by design.
-            let rows = crate::scores::extract_rows(&resolved);
             crate::println!("{}", crate::scores::HEADERS.join("\t"))?;
-            for row in &rows {
-                crate::println!("{}", row.join("\t"))?;
+            for section in sections {
+                for row in &section.rows {
+                    crate::println!("{}", row.join("\t"))?;
+                }
             }
         }
         "pinemhi" => {
             // Section-based layout matching PINemHi's output shape: separate
             // GRAND CHAMPION block when present, one HIGH SCORES block for
             // ranked entries, one section per mode champion.
-            let sections = crate::scores::extract_sections(&resolved);
             // Branch on the locale type rather than using a `&dyn Format` -
             // num-format's ToFormattedString requires Sized. Windows lacks
             // SystemLocale (see Cargo.toml note) so it always uses Locale::en.
             #[cfg(not(windows))]
             let rendered = if let Some(sys) = readable_system_locale() {
-                crate::scores::render_pinemhi(&sections, &sys)
+                crate::scores::render_pinemhi(sections, &sys)
             } else {
-                crate::scores::render_pinemhi(&sections, &num_format::Locale::en)
+                crate::scores::render_pinemhi(sections, &num_format::Locale::en)
             };
             #[cfg(windows)]
-            let rendered = crate::scores::render_pinemhi(&sections, &num_format::Locale::en);
+            let rendered = crate::scores::render_pinemhi(sections, &num_format::Locale::en);
             crate::print!("{}", rendered)?;
         }
         _ => {
             // Human table view: drop the trailing UNITS column after using
             // it to format the SCORE column (e.g. seconds -> mm:ss).
-            let mut rows = crate::scores::extract_rows(&resolved);
+            let mut rows: Vec<Vec<String>> =
+                sections.iter().flat_map(|s| s.rows.iter().cloned()).collect();
             #[cfg(not(windows))]
             if let Some(sys) = readable_system_locale() {
                 crate::scores::pretty_score_column(&mut rows, &sys);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1921,8 +1921,10 @@ fn render_sections(sections: &[crate::scores::Section], format: &str) -> io::Res
         _ => {
             // Human table view: drop the trailing UNITS column after using
             // it to format the SCORE column (e.g. seconds -> mm:ss).
-            let mut rows: Vec<Vec<String>> =
-                sections.iter().flat_map(|s| s.rows.iter().cloned()).collect();
+            let mut rows: Vec<Vec<String>> = sections
+                .iter()
+                .flat_map(|s| s.rows.iter().cloned())
+                .collect();
             #[cfg(not(windows))]
             if let Some(sys) = readable_system_locale() {
                 crate::scores::pretty_score_column(&mut rows, &sys);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -663,6 +663,17 @@ pub fn get_romname_from_vpx(vpx_path: &Path) -> io::Result<Option<String>> {
     }
 }
 
+/// Read the script's `cGameName` (or FlexDMD `.GameName`) constant regardless
+/// of whether the table is PinMAME-based. Companion to [`get_romname_from_vpx`]
+/// for callers that need the in-script identifier as a section/file key (e.g.
+/// `[<cGameName>]` in VPReg.ini, `<cGameName>_glf.ini` for GLF tables).
+pub fn get_gamename_from_vpx(vpx_path: &Path) -> io::Result<Option<String>> {
+    let mut vpx_file = vpx::open(vpx_path)?;
+    let game_data = vpx_file.read_gamedata()?;
+    let code = consider_sidecar_vbs(vpx_path, game_data)?;
+    Ok(extract_game_name(&code))
+}
+
 fn read_table_info_json(info_file_path: &Path) -> io::Result<TableInfo> {
     let info_file = File::open(info_file_path)?;
     let reader = BufReader::new(info_file);

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -14,6 +14,8 @@
 use num_format::{Format, ToFormattedString};
 use serde_json::Value;
 
+pub mod vpreg;
+
 /// Numeric value keys we accept on a score entry, in priority order. Maps for
 /// regular high-scores use `score`; mode-champion maps use `counter` and
 /// occasionally `nth time`.

--- a/src/scores/vpreg.rs
+++ b/src/scores/vpreg.rs
@@ -1,0 +1,282 @@
+//! Read high scores from a VPReg.ini file.
+//!
+//! `VPReg.ini` is the standalone-vpinball stand-in for the Windows registry
+//! that the in-VBS `LoadValue` / `SaveValue` calls (from `core.vbs`) target.
+//! Each table writes its data under a `[<cGameName>]` section. The modern
+//! convention used by all rom-less tables we care about here is:
+//!
+//! ```ini
+//! [TheMatrix]
+//! HighScore1=1154150
+//! HighScore1Name=SOM
+//! HighScore2=100000
+//! HighScore2Name=AAA
+//! ...
+//! Credits=5
+//! TotalGamesPlayed=4
+//! ```
+//!
+//! The exact entry count varies per table (1, 4, 5, 12, and 16 all observed
+//! in the wild - Stern tables in particular keep 16 ranks). Some tables omit
+//! the `HighScoreNName` keys entirely (score-only ranked lists like Volkan).
+//! Non-score keys in the same section (`Credits`, `TotalGamesPlayed`,
+//! `MasterVol`, `SETDIPS`, ...) are ignored.
+//!
+//! An older legacy pattern (`hiscore=N` plus `hsa1`/`hsa2`/`hsa3` for
+//! encoded-character initials, used by some EM tables) is intentionally out
+//! of scope here; only the `HighScoreN` / `HighScoreNName` pattern is parsed.
+//!
+//! The section name must be passed in explicitly - it is the script's
+//! `cGameName` constant and the .ini key does not encode it any other way.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use ini::Ini;
+
+use super::Section;
+
+/// Outcome of looking for a `[section]` in a VPReg.ini.
+#[derive(Debug, PartialEq, Eq)]
+pub enum LookupError {
+    /// The section exists but has no `HighScoreN` keys. Common for tables
+    /// that store only settings (e.g. PinMAME tables that use VPReg.ini
+    /// for SETDIPS but keep scores in the nvram).
+    SectionHasNoScores,
+    /// The .ini file has no `[section]` matching the script's `cGameName`.
+    SectionNotFound,
+    /// The .ini file is unreadable or malformed.
+    ParseFailed(String),
+}
+
+/// Read the score section for `game_name` from `vpreg_path`, returning a
+/// single ranked `HIGH SCORES` section. The rows match the same column shape
+/// as the rest of the scores pipeline: `[label, initials, score, units]`,
+/// with `label` set to `"#N"` for traceability and `units` always empty
+/// (VPReg.ini scores are unitless integers).
+pub fn read_sections(vpreg_path: &Path, game_name: &str) -> Result<Vec<Section>, LookupError> {
+    let ini =
+        Ini::load_from_file(vpreg_path).map_err(|e| LookupError::ParseFailed(e.to_string()))?;
+    extract_sections(&ini, game_name)
+}
+
+/// Same as [`read_sections`] but operates on an already-parsed `Ini`. Split
+/// out so tests can drive the parser from inline string fixtures without
+/// writing temp files.
+fn extract_sections(ini: &Ini, game_name: &str) -> Result<Vec<Section>, LookupError> {
+    let section = ini
+        .section(Some(game_name))
+        .ok_or(LookupError::SectionNotFound)?;
+
+    // Collect `HighScoreN` / `HighScoreNName` pairs keyed by N so we render
+    // them in rank order regardless of the .ini's physical key ordering.
+    // BTreeMap gives us a stable ascending iteration which is what we want.
+    let mut scores: BTreeMap<u32, &str> = BTreeMap::new();
+    let mut names: BTreeMap<u32, &str> = BTreeMap::new();
+    for (key, value) in section.iter() {
+        if let Some(rest) = key.strip_prefix("HighScore") {
+            if let Some(n_str) = rest.strip_suffix("Name") {
+                if let Ok(n) = n_str.parse::<u32>() {
+                    names.insert(n, value);
+                }
+            } else if let Ok(n) = rest.parse::<u32>() {
+                scores.insert(n, value);
+            }
+        }
+    }
+
+    if scores.is_empty() {
+        return Err(LookupError::SectionHasNoScores);
+    }
+
+    let rows: Vec<Vec<String>> = scores
+        .into_iter()
+        .map(|(n, score)| {
+            let initials = names.get(&n).copied().unwrap_or("").trim().to_string();
+            vec![
+                format!("#{n}"),
+                initials,
+                score.trim().to_string(),
+                String::new(),
+            ]
+        })
+        .collect();
+
+    let ranked = rows.len() > 1;
+    let header = if ranked {
+        "HIGH SCORES".to_string()
+    } else {
+        // Single-entry section: use the table's section name as the header
+        // (uppercased to match the pinmame branch's convention) since the
+        // row itself has a rank-shaped label and there is nothing else to
+        // hang the header off.
+        game_name.to_uppercase()
+    };
+
+    Ok(vec![Section {
+        header,
+        rows,
+        ranked,
+    }])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn parse(content: &str) -> Ini {
+        Ini::load_from_str(content).expect("ini parse")
+    }
+
+    #[test]
+    fn parses_modern_four_entry_section() {
+        // Matrix (Original 2023) - real shape with names alongside scores.
+        let ini = parse(
+            r"
+[TheMatrix]
+HighScore1=1154150
+HighScore1Name=SOM
+HighScore2=100000
+HighScore2Name=AAA
+HighScore3=100000
+HighScore3Name=BBB
+HighScore4=100000
+HighScore4Name=CCC
+Credits=5
+TotalGamesPlayed=4
+",
+        );
+        let sections = extract_sections(&ini, "TheMatrix").expect("section");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].header, "HIGH SCORES");
+        assert!(sections[0].ranked);
+        assert_eq!(sections[0].rows.len(), 4);
+        assert_eq!(sections[0].rows[0], vec!["#1", "SOM", "1154150", ""]);
+        assert_eq!(sections[0].rows[3], vec!["#4", "CCC", "100000", ""]);
+    }
+
+    #[test]
+    fn parses_section_with_scores_but_no_names() {
+        // Volkan Steel and Metal: 12 HighScoreN keys, no HighScoreNName.
+        let ini = parse(
+            r"
+[volkan]
+HighScore1=20000
+HighScore2=30000
+HighScore3=50000
+",
+        );
+        let sections = extract_sections(&ini, "volkan").expect("section");
+        assert_eq!(sections[0].rows[0], vec!["#1", "", "20000", ""]);
+        assert_eq!(sections[0].rows[2], vec!["#3", "", "50000", ""]);
+    }
+
+    #[test]
+    fn orders_by_rank_number_not_ini_order() {
+        // 16-entry Stern-style table; verify N=10..16 sort correctly after
+        // N=1..9 (string ordering of "HighScore10" < "HighScore2" would
+        // break this if we forgot to parse N as an integer).
+        let ini = parse(
+            r"
+[gameofthrones]
+HighScore2=500000000
+HighScore2Name=BBB
+HighScore10=7000000
+HighScore10Name=JJJ
+HighScore1=750000000
+HighScore1Name=AAA
+",
+        );
+        let sections = extract_sections(&ini, "gameofthrones").expect("section");
+        let labels: Vec<&str> = sections[0].rows.iter().map(|r| r[0].as_str()).collect();
+        assert_eq!(labels, vec!["#1", "#2", "#10"]);
+    }
+
+    #[test]
+    fn single_entry_section_marks_unranked_and_uses_section_header() {
+        // Loch Ness Monster: just one HighScore1 entry, no name. Treat as
+        // an unranked single-entry section so the renderer doesn't prefix
+        // the lone row with "1.".
+        let ini = parse(
+            r"
+[Lochness]
+HighScore1=100000
+Credits=0
+TotalGamesPlayed=0
+",
+        );
+        let sections = extract_sections(&ini, "Lochness").expect("section");
+        assert_eq!(sections.len(), 1);
+        assert!(!sections[0].ranked);
+        assert_eq!(sections[0].header, "LOCHNESS");
+        assert_eq!(sections[0].rows.len(), 1);
+    }
+
+    #[test]
+    fn ignores_unrelated_keys_in_the_section() {
+        // Credits/TotalGamesPlayed/MasterVol/SETDIPS commonly live alongside
+        // the HighScore keys; the parser must skip them silently.
+        let ini = parse(
+            r"
+[somegame]
+SETDIPS=0
+HighScore1=42
+HighScore1Name=FOO
+MasterVol=99
+Credits=3
+TotalGamesPlayed=7
+",
+        );
+        let sections = extract_sections(&ini, "somegame").expect("section");
+        assert_eq!(sections[0].rows[0], vec!["#1", "FOO", "42", ""]);
+        assert_eq!(sections[0].rows.len(), 1);
+    }
+
+    #[test]
+    fn returns_section_not_found_when_game_name_missing() {
+        let ini = parse(
+            r"
+[OtherGame]
+HighScore1=10
+",
+        );
+        let err = extract_sections(&ini, "TheMatrix").expect_err("should miss");
+        assert_eq!(err, LookupError::SectionNotFound);
+    }
+
+    #[test]
+    fn returns_no_scores_when_section_has_only_settings() {
+        // Haunted House's [hh] section only carries SETDIPS, the actual
+        // scores live in the pinmame nvram. We surface this distinctly
+        // from "section missing" so the caller can fall through cleanly.
+        let ini = parse(
+            r"
+[hh]
+SETDIPS=0
+",
+        );
+        let err = extract_sections(&ini, "hh").expect_err("should be empty");
+        assert_eq!(err, LookupError::SectionHasNoScores);
+    }
+
+    #[test]
+    fn ignores_legacy_hiscore_and_hsa_keys() {
+        // Older VBS pattern: `hiscore=10000` + `hsa1`/`hsa2`/`hsa3` for
+        // encoded initials. We intentionally do not parse these here;
+        // a section that has only legacy keys is reported as having no
+        // scores so the dispatcher can move on.
+        let ini = parse(
+            r"
+[Abra_Ca_Dabra]
+hiscore=10000
+hsa1=4
+hsa2=15
+hsa3=7
+score1=1910
+",
+        );
+        let err = extract_sections(&ini, "Abra_Ca_Dabra").expect_err("legacy ignored");
+        assert_eq!(err, LookupError::SectionHasNoScores);
+    }
+}


### PR DESCRIPTION
## Summary
- `scores show <table.vpx>` now resolves rom-less tables by probing `user/VPReg.ini` (then sibling `VPReg.ini`) for the script's `cGameName` section and parsing the modern `HighScoreN` / `HighScoreNName` pattern.
- PinMAME path (`.nv`, `.zip`, `.vpx` with a ROM) is unchanged; VPReg only kicks in when PinMAME resolution returns `NotPinmame` / `NoNvramFor`.
- Entry counts (1, 4, 5, 12, 16 all seen in the wild) and missing-names variants are both handled.
- Older VBS keys (`hiscore=` + `hsa1/2/3`, `score1/2`) intentionally skipped so GLF/Black's follow-ups can layer in.

## Test plan
- [x] `cargo test --lib scores` (30 passing, 8 new VPReg cases)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Eyeballed The Matrix (Original 2023) .vpx in all three formats; SOM 1,154,150 shows correctly with locale-aware grouping and aligned columns.
- [x] Regression: baywatch.nv still renders identically.