### PR TITLE
feat(scores): support single-hisc EM tables (no initials)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1875,48 +1875,51 @@ fn try_non_pinmame_fallback(
     if !should_try {
         return Ok(None);
     }
-    let Some(game_name) = indexer::get_gamename_from_vpx(expanded_path)? else {
-        return Ok(None);
-    };
     let vpx_parent = expanded_path.parent().unwrap_or(Path::new("."));
 
-    // VPReg: `user/VPReg.ini` first because standalone vpinball writes there
-    // by default; sibling as a fallback for older layouts.
-    let vpreg_candidates = [
-        vpx_parent.join("user").join("VPReg.ini"),
-        vpx_parent.join("VPReg.ini"),
-    ];
-    for candidate in &vpreg_candidates {
-        if !candidate.is_file() {
-            continue;
-        }
-        match crate::scores::vpreg::read_sections(candidate, &game_name) {
-            Ok(sections) => return Ok(Some(sections)),
-            Err(crate::scores::vpreg::LookupError::SectionNotFound)
-            | Err(crate::scores::vpreg::LookupError::SectionHasNoScores) => continue,
-            Err(crate::scores::vpreg::LookupError::ParseFailed(msg)) => {
-                return Err(io::Error::other(format!(
-                    "Failed to parse {}: {msg}",
-                    candidate.display()
-                )));
+    // VPReg and GLF key off the script's cGameName; skip them when the
+    // script doesn't declare one (some early-EM tables don't). The EMHS
+    // glob still runs since it doesn't need a name.
+    let game_name = indexer::get_gamename_from_vpx(expanded_path)?;
+    if let Some(ref game_name) = game_name {
+        // VPReg: `user/VPReg.ini` first because standalone vpinball writes
+        // there by default; sibling as a fallback for older layouts.
+        let vpreg_candidates = [
+            vpx_parent.join("user").join("VPReg.ini"),
+            vpx_parent.join("VPReg.ini"),
+        ];
+        for candidate in &vpreg_candidates {
+            if !candidate.is_file() {
+                continue;
+            }
+            match crate::scores::vpreg::read_sections(candidate, game_name) {
+                Ok(sections) => return Ok(Some(sections)),
+                Err(crate::scores::vpreg::LookupError::SectionNotFound)
+                | Err(crate::scores::vpreg::LookupError::SectionHasNoScores) => continue,
+                Err(crate::scores::vpreg::LookupError::ParseFailed(msg)) => {
+                    return Err(io::Error::other(format!(
+                        "Failed to parse {}: {msg}",
+                        candidate.display()
+                    )));
+                }
             }
         }
-    }
 
-    // GLF: `<cGameName>_glf.ini` sibling of the .vpx.
-    let glf_path = vpx_parent.join(format!("{game_name}_glf.ini"));
-    if glf_path.is_file() {
-        match crate::scores::glf::read_sections(&glf_path) {
-            Ok(sections) => return Ok(Some(sections)),
-            // GLF file present but no usable scores - return None so the
-            // caller surfaces the original PinMAME error.
-            Err(crate::scores::glf::LookupError::NoHighScoresSection)
-            | Err(crate::scores::glf::LookupError::EmptyHighScores) => {}
-            Err(crate::scores::glf::LookupError::ParseFailed(msg)) => {
-                return Err(io::Error::other(format!(
-                    "Failed to parse {}: {msg}",
-                    glf_path.display()
-                )));
+        // GLF: `<cGameName>_glf.ini` sibling of the .vpx.
+        let glf_path = vpx_parent.join(format!("{game_name}_glf.ini"));
+        if glf_path.is_file() {
+            match crate::scores::glf::read_sections(&glf_path) {
+                Ok(sections) => return Ok(Some(sections)),
+                // GLF file present but no usable scores - return None so the
+                // caller surfaces the original PinMAME error.
+                Err(crate::scores::glf::LookupError::NoHighScoresSection)
+                | Err(crate::scores::glf::LookupError::EmptyHighScores) => {}
+                Err(crate::scores::glf::LookupError::ParseFailed(msg)) => {
+                    return Err(io::Error::other(format!(
+                        "Failed to parse {}: {msg}",
+                        glf_path.display()
+                    )));
+                }
             }
         }
     }

--- a/src/scores/emhs.rs
+++ b/src/scores/emhs.rs
@@ -64,8 +64,17 @@ pub enum LookupError {
 /// Read a Black's-style score file and return a single ranked HIGH SCORES
 /// section. Entries with a score of `0` (default-zero, never-played slots)
 /// are dropped to mirror PinMAME / VPReg behavior.
+///
+/// Non-UTF-8 bytes (commonly CP1252 smart-quotes / en-dashes in
+/// human-authored README files that happen to share the same folder) are
+/// replaced with U+FFFD via [`String::from_utf8_lossy`]. The replacement
+/// chars never match the integer-or-short-initials test in the block
+/// scanner, so non-score files fall through as [`LookupError::PatternNotFound`]
+/// instead of bombing with a fatal read error. Real score files are pure
+/// ASCII (digits + 3-char initials) so this is a no-op for them.
 pub fn read_sections(path: &Path) -> Result<Vec<Section>, LookupError> {
-    let raw = std::fs::read_to_string(path).map_err(|e| LookupError::ReadFailed(e.to_string()))?;
+    let bytes = std::fs::read(path).map_err(|e| LookupError::ReadFailed(e.to_string()))?;
+    let raw = String::from_utf8_lossy(&bytes);
     extract_sections_from_text(&raw)
 }
 
@@ -199,6 +208,26 @@ mod tests {
         assert_eq!(sections[0].rows.len(), 3);
         let names: Vec<&str> = sections[0].rows.iter().map(|r| r[1].as_str()).collect();
         assert_eq!(names, vec!["AAA", "BBB", "CCC"]);
+    }
+
+    #[test]
+    fn read_sections_treats_non_utf8_readme_as_pattern_not_found() {
+        // Real-world: README files in the same folder as the .vpx get
+        // picked up by the glob; many are Windows CP1252 (smart-quote
+        // 0x92, en-dash 0x96). The lossy decoder converts those to
+        // U+FFFD, which fails the integer/short-initials test, so the
+        // file falls through with PatternNotFound rather than aborting
+        // the whole scores show invocation.
+        let dir = std::env::temp_dir().join(format!("vpxtool-emhs-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir tmp");
+        let path = dir.join("readme_cp1252.txt");
+        // 0x92 = curly apostrophe in CP1252; invalid as standalone UTF-8.
+        let bytes: &[u8] = b"Welcome to the world\x92s most famous table.\nInstructions follow.\n";
+        std::fs::write(&path, bytes).expect("write fixture");
+        let err = read_sections(&path).expect_err("non-utf8 readme should not parse");
+        assert_eq!(err, LookupError::PatternNotFound);
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
     }
 
     #[test]

--- a/src/scores/emhs.rs
+++ b/src/scores/emhs.rs
@@ -33,15 +33,21 @@
 //!                                   BBB      -'
 //! ```
 //!
+//! Older EM tables (typically pre-1970, e.g. "2 in 1 (Bally 1964)",
+//! "4 Queens (Bally 1970)") have a simpler variant: a single high score
+//! and **no initials** at all. The on-disk file is a sequence of plain
+//! integers with no string lines anywhere. We handle this as a second
+//! strategy: when the 5+5 scan fails, fall back to an "all-integer file
+//! whose max value is the high score" rule. The all-integer anchor cleanly
+//! separates these from the 5+5 format (which always has 5 string lines).
+//!
 //! Filename is also non-canonical: some tables use `<cGameName>.txt`, some
 //! use `<TableName>.txt` (a separate constant), some hard-code an unrelated
 //! literal in the VBS. That makes auto-detection a glob + parse rather than
 //! a name lookup - the dispatcher tries each `*.txt` in the candidate
 //! folders and keeps the first one that yields a valid score block.
 //!
-//! The parser is deliberately strict on the *block shape* (5+5 contiguous,
-//! integers then non-integer strings) but lenient on surrounding noise.
-//! Tables that diverge from the 5+5 convention are reported as
+//! Tables that fit neither shape are reported as
 //! [`LookupError::PatternNotFound`] so the caller can keep probing.
 
 use std::path::Path;
@@ -53,9 +59,9 @@ const MAX_INITIALS_LEN: usize = 4;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum LookupError {
-    /// No `<5 ints, 5 short non-int strings>` window found anywhere in the
-    /// file. Either it's not a Black's-style score file or it follows a
-    /// variant we don't recognize.
+    /// Neither the 5-ints-then-5-initials Black's block nor the
+    /// all-integer single-hisc shape was found. Either it's not an EM
+    /// score file or it follows a variant we don't recognize.
     PatternNotFound,
     /// I/O failure reading the file.
     ReadFailed(String),
@@ -78,6 +84,10 @@ pub fn read_sections(path: &Path) -> Result<Vec<Section>, LookupError> {
     extract_sections_from_text(&raw)
 }
 
+/// Minimum line count for the all-integer single-hisc fallback. Filters out
+/// 1- or 2-integer config-y files that happen to be all numbers.
+const MIN_SINGLE_HISC_LINES: usize = 4;
+
 /// In-memory variant for tests. Split out so we can drive the parser from
 /// string fixtures without writing temp files.
 fn extract_sections_from_text(text: &str) -> Result<Vec<Section>, LookupError> {
@@ -86,8 +96,19 @@ fn extract_sections_from_text(text: &str) -> Result<Vec<Section>, LookupError> {
         .map(str::trim)
         .filter(|l| !l.is_empty())
         .collect();
-    let (scores, names) = find_score_block(&lines).ok_or(LookupError::PatternNotFound)?;
+    if let Some(sections) = try_score_block(&lines) {
+        return Ok(sections);
+    }
+    if let Some(sections) = try_single_hisc(&lines) {
+        return Ok(sections);
+    }
+    Err(LookupError::PatternNotFound)
+}
 
+/// First strategy: locate the canonical 5-scores-then-5-initials Black's
+/// block. Returns `None` when no such block exists in the file.
+fn try_score_block(lines: &[&str]) -> Option<Vec<Section>> {
+    let (scores, names) = find_score_block(lines)?;
     let rows: Vec<Vec<String>> = scores
         .iter()
         .zip(names.iter())
@@ -104,15 +125,55 @@ fn extract_sections_from_text(text: &str) -> Result<Vec<Section>, LookupError> {
             ]
         })
         .collect();
-
     if rows.is_empty() {
-        return Err(LookupError::PatternNotFound);
+        return None;
     }
     let ranked = rows.len() > 1;
-    Ok(vec![Section {
+    Some(vec![Section {
         header: "HIGH SCORES".to_string(),
         rows,
         ranked,
+    }])
+}
+
+/// Second strategy: single-hisc EM tables. Older EM tables (typically
+/// pre-1970) store one high score with no initials. The on-disk file is
+/// a small sequence of integers (credits, current-game scores, the single
+/// high score, dip settings, ...) with no labels and no initials.
+///
+/// Anchor: the file is **all integer lines**, no string lines anywhere
+/// (Black's 5+5 files always have 5 string lines, so this filter cleanly
+/// separates the two formats). We additionally require [`MIN_SINGLE_HISC_LINES`]
+/// or more lines so a 1-2 line config file can't trigger the fallback.
+///
+/// The high score itself is the **maximum integer** in the file. For these
+/// tables, `hisc` dwarfs every other field (credits, current-game scores
+/// during a play that hasn't finished, dip indices) - we surveyed real
+/// played files (2 in 1: max=1000, 4 Queens: max=50000) and the heuristic
+/// holds. Returns `None` when the file doesn't fit the all-integer shape.
+fn try_single_hisc(lines: &[&str]) -> Option<Vec<Section>> {
+    if lines.len() < MIN_SINGLE_HISC_LINES {
+        return None;
+    }
+    let ints: Vec<u64> = lines
+        .iter()
+        .map(|l| l.parse::<u64>().ok())
+        .collect::<Option<Vec<_>>>()?;
+    let max = *ints.iter().max()?;
+    if max == 0 {
+        // All zeros - unplayed slots; treat as "no high score yet" so the
+        // dispatcher keeps probing other backends/files.
+        return None;
+    }
+    Some(vec![Section {
+        header: "HIGH SCORE".to_string(),
+        rows: vec![vec![
+            "HIGH SCORE".to_string(),
+            String::new(),
+            max.to_string(),
+            String::new(),
+        ]],
+        ranked: false,
     }])
 }
 
@@ -272,10 +333,63 @@ mod tests {
     }
 
     #[test]
+    fn parses_single_hisc_2_in_1_shape() {
+        // Real 2 in 1 (Bally 1964) user/2in1.txt after one game:
+        // credit / score(0) / score(1) / hisc / wv / mv / qs / extra.
+        let text = "11\n0\n321\n1000\n8\n7\n1\n0\n";
+        let sections = extract_sections_from_text(text).expect("section");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].header, "HIGH SCORE");
+        assert!(!sections[0].ranked);
+        assert_eq!(sections[0].rows.len(), 1);
+        assert_eq!(sections[0].rows[0], vec!["HIGH SCORE", "", "1000", ""]);
+    }
+
+    #[test]
+    fn parses_single_hisc_4_queens_shape() {
+        // Real 4 Queens (Bally 1970) user/4Queens70.txt: 6 integer lines
+        // with the high score being 50000 (well above credits/dips).
+        let text = "0\n0\n0\n50000\n12\n0\n";
+        let sections = extract_sections_from_text(text).expect("section");
+        assert_eq!(sections[0].rows[0][2], "50000");
+    }
+
+    #[test]
+    fn single_hisc_rejects_short_files() {
+        // 3-line all-integer files (typically dip-only config remnants)
+        // don't qualify; we require at least MIN_SINGLE_HISC_LINES.
+        let text = "12\n0\n1\n";
+        let err = extract_sections_from_text(text).expect_err("too short");
+        assert_eq!(err, LookupError::PatternNotFound);
+    }
+
+    #[test]
+    fn single_hisc_rejects_all_zero_files() {
+        // A freshly-initialized score file with every slot at 0 must NOT
+        // claim a high score - return PatternNotFound so the user sees
+        // "no high scores yet" rather than a bogus "HIGH SCORE 0".
+        let text = "0\n0\n0\n0\n0\n";
+        let err = extract_sections_from_text(text).expect_err("all zero");
+        assert_eq!(err, LookupError::PatternNotFound);
+    }
+
+    #[test]
+    fn single_hisc_rejects_files_with_any_string_line() {
+        // Anything that isn't a plain integer (or empty line) disqualifies
+        // the file. Catches README-style content cleanly without needing
+        // a separate length check.
+        let text = "12\n0\nSomeReadme\n1000\n";
+        let err = extract_sections_from_text(text).expect_err("has prose");
+        assert_eq!(err, LookupError::PatternNotFound);
+    }
+
+    #[test]
     fn rejects_window_where_names_are_all_digits() {
-        // Names that are all-digit get rejected so a sequence like
-        // `5 ints + 5 ints` doesn't accidentally match.
-        let text = "100\n90\n80\n70\n60\n1\n2\n3\n4\n5\n";
+        // The Black's 5+5 scanner must reject a "5 ints + 5 ints" run
+        // (initials-half all-digit) so we don't lift counters as names.
+        // A trailing non-integer line keeps the single-hisc fallback out
+        // of the picture too, so this stays a PatternNotFound end-to-end.
+        let text = "100\n90\n80\n70\n60\n1\n2\n3\n4\n5\nGARBAGE\n";
         let err = extract_sections_from_text(text).expect_err("should not match");
         assert_eq!(err, LookupError::PatternNotFound);
     }


### PR DESCRIPTION
## Summary
Older EM tables (typically pre-1970 like 2 in 1 (Bally 1964), 4 Queens (Bally 1970)) store a single high score with no initials. The .txt file is pure-integer-per-line and never matches the 5+5 Black's block, so they fell through with "no high scores found" even after gameplay.

## What's new
- `emhs::extract_sections_from_text` gets a second strategy after the 5+5 scan misses: if every non-empty line is an integer and there are >=4 lines, return a single-row HIGH SCORE whose value is the max integer in the file. The all-integer anchor cleanly distinguishes this from the 5+5 shape (which always has 5 string lines).
- **Dispatcher fix**: `try_non_pinmame_fallback` used to early-return when cGameName was missing, blocking the EMHS glob for any rom-less table without a `Const cGameName` (common on very-early EM scripts). VPReg and GLF still need the name; EMHS doesn't.

## Coverage / verification
- Surveyed 1091 tables in a real collection: zero false positives for the all-integer anchor. The only two candidate files (2in1.txt, 4Queens70.txt) are both legitimate score files.
- 6 new unit tests cover both real shapes and reject too-short / all-zero / has-prose / dispatcher-edge cases. 138/138 tests pass.
- End-to-end: 2 in 1 now reports HIGH SCORE 1000, 4 Queens reports 50000. Carnaval / 8 Ball / Roller Coaster (5+5) regression-clean.
- Full re-scan: 4 additional tables move OK; the "could not find any high scores" bucket drops accordingly.