### PR TITLE
feat(scores): multi-section-key VPReg lookup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1313,10 +1313,13 @@ fn build_command() -> Command {
                              tables (.nv/.zip or .vpx with a ROM) are resolved through the \
                              pinmame-nvram maps. For rom-less .vpx tables, three non-PinMAME \
                              backends are probed in order: `VPReg.ini` (in `user/` first, \
-                             then sibling) keyed by the script's cGameName; a \
-                             `<cGameName>_glf.ini` sibling (GLF framework); and any \
-                             `user/*.txt` / `*.txt` files containing a 5-scores-then-5- \
-                             initials block (EM tables using Black's Highscore routines).\n\
+                             then sibling) keyed by every distinct section name the script \
+                             references in `(Load|Save)Value(<arg>, \"HighScore...\")` calls \
+                             (so cGameName, TableName, MyTable, hardcoded literals, ... all \
+                             resolve); a `<cGameName>_glf.ini` sibling (GLF framework); and \
+                             any `user/*.txt` / `*.txt` files containing a 5-scores-then-5- \
+                             initials block or a single-hisc all-integer file (EM tables \
+                             using Black's Highscore routines).\n\
                              \n\
                              Default format is an aligned LABEL / INITIALS / SCORE table \
                              with comma-grouped scores. `--format tsv` emits tab-separated \
@@ -1877,22 +1880,23 @@ fn try_non_pinmame_fallback(
     }
     let vpx_parent = expanded_path.parent().unwrap_or(Path::new("."));
 
-    // VPReg and GLF key off the script's cGameName; skip them when the
-    // script doesn't declare one (some early-EM tables don't). The EMHS
-    // glob still runs since it doesn't need a name.
-    let game_name = indexer::get_gamename_from_vpx(expanded_path)?;
-    if let Some(ref game_name) = game_name {
-        // VPReg: `user/VPReg.ini` first because standalone vpinball writes
-        // there by default; sibling as a fallback for older layouts.
-        let vpreg_candidates = [
-            vpx_parent.join("user").join("VPReg.ini"),
-            vpx_parent.join("VPReg.ini"),
-        ];
-        for candidate in &vpreg_candidates {
-            if !candidate.is_file() {
-                continue;
-            }
-            match crate::scores::vpreg::read_sections(candidate, game_name) {
+    // VPReg: extract every distinct section key the script writes under
+    // (the modern pattern uses `cGameName`, but `TableName`, `MyTable`,
+    // `cGameSaveName`, and hardcoded literals are all common in the wild).
+    // Probe each VPReg.ini candidate against every key the script names
+    // and return the first hit. `user/VPReg.ini` is checked before the
+    // sibling because standalone vpinball writes there by default.
+    let vpreg_keys = indexer::get_vpreg_section_keys_from_vpx(expanded_path)?;
+    let vpreg_candidates = [
+        vpx_parent.join("user").join("VPReg.ini"),
+        vpx_parent.join("VPReg.ini"),
+    ];
+    for candidate in &vpreg_candidates {
+        if !candidate.is_file() {
+            continue;
+        }
+        for key in &vpreg_keys {
+            match crate::scores::vpreg::read_sections(candidate, key) {
                 Ok(sections) => return Ok(Some(sections)),
                 Err(crate::scores::vpreg::LookupError::SectionNotFound)
                 | Err(crate::scores::vpreg::LookupError::SectionHasNoScores) => continue,
@@ -1904,8 +1908,12 @@ fn try_non_pinmame_fallback(
                 }
             }
         }
+    }
 
-        // GLF: `<cGameName>_glf.ini` sibling of the .vpx.
+    // GLF still keys off cGameName specifically because the vpx-glf
+    // framework hardcodes `<CGameName>_glf.ini` as the filename.
+    let game_name = indexer::get_gamename_from_vpx(expanded_path)?;
+    if let Some(ref game_name) = game_name {
         let glf_path = vpx_parent.join(format!("{game_name}_glf.ini"));
         if glf_path.is_file() {
             match crate::scores::glf::read_sections(&glf_path) {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -35,6 +35,22 @@ static LINE_WITH_DOT_GAMENAME_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
 static LOADVPM_SUB_REGEX: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r#"sub\s*loadvpm"#).unwrap());
 
+// Pulls a `Const <id> = "..."` declaration. `(?m)` so `^` matches the start
+// of each line (constants always appear at top-level in VBS).
+static CONST_DECL_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"(?im)^\s*Const\s+([A-Za-z_]\w*)\s*=\s*"([^"]*)""#).unwrap()
+});
+
+// Matches `(Load|Save)Value(<arg>, "HighScore<N>")` or `...Name"`. Captures
+// the section-key argument (an identifier or a quoted literal) so the
+// dispatcher can try every distinct section name a script writes under.
+static VPREG_HIGHSCORE_CALL_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r#"(?i)(?:Load|Save)Value\s*\(?\s*([A-Za-z_]\w*|"[^"\r\n]+")\s*,\s*"HighScore\d+(?:Name)?""#,
+    )
+    .unwrap()
+});
+
 /// Introduced because we want full control over serialization
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct IndexedTableInfo {
@@ -674,6 +690,73 @@ pub fn get_gamename_from_vpx(vpx_path: &Path) -> io::Result<Option<String>> {
     Ok(extract_game_name(&code))
 }
 
+/// Pull every distinct VPReg.ini section key a script writes under, in
+/// first-seen order. A real table can use a mix of section names per
+/// `LoadValue(<arg>, "HighScoreN")` call: a constant (`cGameName`,
+/// `TableName`, `MyTable`, `cGameSaveName`, ...) or a hardcoded literal.
+/// The dispatcher iterates this list when probing VPReg, so it doesn't
+/// matter which convention the script chose - whichever section happens
+/// to be present in the on-disk VPReg.ini will resolve.
+pub fn get_vpreg_section_keys_from_vpx(vpx_path: &Path) -> io::Result<Vec<String>> {
+    let mut vpx_file = vpx::open(vpx_path)?;
+    let game_data = vpx_file.read_gamedata()?;
+    let code = consider_sidecar_vbs(vpx_path, game_data)?;
+    Ok(extract_vpreg_section_keys(&code))
+}
+
+/// Two-pass scan over a VBS script:
+///   1. Collect every `Const <id> = "..."` declaration into a lookup map.
+///      Identifier comparison is case-insensitive (VBS itself treats
+///      identifiers case-insensitively).
+///   2. Walk `(Load|Save)Value(<arg>, "HighScore...")` call sites; for each
+///      `<arg>` that's a quoted literal use it directly, otherwise resolve
+///      it against the Const map. Unknown identifiers are skipped silently.
+///
+/// Returns the distinct list of section keys preserving the order of first
+/// occurrence in the script. Comments (lines starting with `'`) are stripped
+/// before either pass so a commented-out example doesn't pollute the result.
+fn extract_vpreg_section_keys<S: AsRef<str>>(code: S) -> Vec<String> {
+    let unified = unify_line_endings(code.as_ref());
+    let stripped: String = unified
+        .lines()
+        .map(|line| {
+            // Naive comment strip: cuts at the first single-quote. VBS
+            // comments can appear mid-line after expressions, and string
+            // literals inside double-quotes shouldn't contain unescaped `'`
+            // for the cases we care about (LoadValue with HighScoreN keys).
+            line.split_once('\'').map(|(c, _)| c).unwrap_or(line)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut consts: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for caps in CONST_DECL_REGEX.captures_iter(&stripped) {
+        let id = caps.get(1).unwrap().as_str().to_ascii_lowercase();
+        let value = caps.get(2).unwrap().as_str().to_string();
+        // First declaration wins: VBS would treat a redeclaration as a
+        // compile error, but tolerate it just in case.
+        consts.entry(id).or_insert(value);
+    }
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    for caps in VPREG_HIGHSCORE_CALL_REGEX.captures_iter(&stripped) {
+        let arg = caps.get(1).unwrap().as_str();
+        let resolved = if arg.starts_with('"') && arg.ends_with('"') && arg.len() >= 2 {
+            // Quoted literal - strip the surrounding quotes.
+            Some(arg[1..arg.len() - 1].to_string())
+        } else {
+            consts.get(&arg.to_ascii_lowercase()).cloned()
+        };
+        if let Some(key) = resolved
+            && seen.insert(key.clone())
+        {
+            out.push(key);
+        }
+    }
+    out
+}
+
 fn read_table_info_json(info_file_path: &Path) -> io::Result<TableInfo> {
     let info_file = File::open(info_file_path)?;
     let reader = BufReader::new(info_file);
@@ -1195,6 +1278,114 @@ mod tests {
     use std::io::Write;
     use testdir::testdir;
     use vpin::vpx;
+
+    #[test]
+    fn extract_vpreg_keys_picks_up_cgamename_const() {
+        // Most common shape: one const referenced from LoadValue calls.
+        let code = r#"
+Const cGameName = "TheMatrix"
+x = LoadValue(cGameName, "HighScore1")
+y = LoadValue(cGameName, "HighScore1Name")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["TheMatrix"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_picks_up_tablename_const() {
+        // Aerosmith-style: the load target is a separate `TableName` const,
+        // distinct from `cGameName`.
+        let code = r#"
+Const cGameName = "aerosmith"
+Const TableName = "aerosmith_VPX"
+x = LoadValue(TableName, "HighScore1")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["aerosmith_VPX"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_picks_up_quoted_literal_section() {
+        // Some scripts hardcode the section name inline.
+        let code = r#"
+SaveValue "MyHardcodedKey", "HighScore1", 1000
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["MyHardcodedKey"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_returns_distinct_first_seen_order() {
+        // Iron Maiden-style: the script writes under two different consts.
+        // Caller probes them in order so the first-seen one wins when both
+        // sections exist (unusual but real).
+        let code = r#"
+Const cGameName = "ironmaiden"
+Const TableName = "ironmaiden_vr"
+x = LoadValue(cGameName, "HighScore1")
+y = LoadValue(TableName, "HighScore2")
+z = LoadValue(cGameName, "HighScore3")
+"#;
+        assert_eq!(
+            extract_vpreg_section_keys(code),
+            vec!["ironmaiden", "ironmaiden_vr"]
+        );
+    }
+
+    #[test]
+    fn extract_vpreg_keys_resolves_arbitrary_const_names() {
+        // We don't hardcode `cGameName` / `TableName`; any const that's
+        // declared and referenced from a LoadValue call resolves.
+        let code = r#"
+Const MyTable = "DragonBallZ"
+x = LoadValue(MyTable, "HighScore1")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["DragonBallZ"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_ignores_unresolved_identifiers() {
+        // If the section-key identifier isn't backed by a `Const X = "..."`
+        // declaration, we can't resolve it - skip silently rather than
+        // pollute the probe list with garbage.
+        let code = r#"
+x = LoadValue(SomeUndefinedVar, "HighScore1")
+"#;
+        assert!(extract_vpreg_section_keys(code).is_empty());
+    }
+
+    #[test]
+    fn extract_vpreg_keys_ignores_non_highscore_loadvalue_calls() {
+        // VPReg also stores LUT image / volume / etc. Those use different
+        // value keys; we only care about HighScoreN/HighScoreNName so the
+        // section list stays focused on scoring code paths.
+        let code = r#"
+Const cGameName = "foo"
+x = LoadValue(cGameName, "LUTImage")
+y = LoadValue(cGameName, "BgVolume")
+"#;
+        assert!(extract_vpreg_section_keys(code).is_empty());
+    }
+
+    #[test]
+    fn extract_vpreg_keys_ignores_commented_out_examples() {
+        // A commented-out example LoadValue call must not contribute.
+        let code = r#"
+Const cGameName = "Real"
+' Const TableName = "OldExample"
+' x = LoadValue(TableName, "HighScore1")
+y = LoadValue(cGameName, "HighScore1")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["Real"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_treats_identifier_case_insensitively() {
+        // VBS identifiers are case-insensitive. A declaration with
+        // `Const TableName` should resolve `tablename`-cased references.
+        let code = r#"
+Const TableName = "MixedCaseHit"
+x = LoadValue(tablename, "HighScore1")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["MixedCaseHit"]);
+    }
 
     #[test]
     fn test_index_vpx_files() -> io::Result<()> {


### PR DESCRIPTION
## Summary
VBS scripts use varied section keys for VPReg.ini high-score storage. Surveying 1090 extracted scripts: of ~155 modern-VPReg tables, only ~74 use `cGameName` (what we previously probed). The remaining ~80 split across `TableName` (Aerosmith, Batman 66, Iron Maiden, ...), hardcoded literals (38), `MyTable` (7), `cGameSaveName` (2), and a few mixed cases.

This PR generalises: a two-pass scan over the VBS collects every `Const X = "..."` declaration and every `(Load|Save)Value(<arg>, "HighScoreN")` call, resolving `<arg>` against the const map or as a literal. The dispatcher probes each resulting key against each VPReg.ini candidate.

PinMAME / GLF paths unchanged - both genuinely key off cGameName (ROM lookup; `<CGameName>_glf.ini` filename).

## Coverage
- Real played table check: Aerosmith resolves (TableName).
- Bulk rescan over 1091 tables: OK 391 -> 400 (+9), no-high-scores bucket 488 -> 479.
- The remaining ~70 TableName/literal/MyTable tables in the user's collection haven't been played yet (no VPReg.ini to populate); they will resolve on first save.

## Tests
- 9 new unit tests in indexer.rs covering cGameName, TableName, quoted literal, mixed, arbitrary const names, unresolved identifiers, non-HighScore LoadValue calls, commented-out examples, case-insensitive lookup.
- 147/147 total tests pass; clippy + fmt clean.