### PR TITLE
fix(scores): case-insensitive VPReg keys + Dim-style assignments

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -41,6 +41,15 @@ static CONST_DECL_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r#"(?im)^\s*Const\s+([A-Za-z_]\w*)\s*=\s*"([^"]*)""#).unwrap()
 });
 
+// Also catch plain `<id> = "..."` assignments (no `Const`), which scripts
+// use after a `Dim <id>` declaration: John Wick, for instance, writes
+// `Dim MyTable` then `MyTable = "JPsIT"` and reads
+// `LoadValue(MyTable, "HighScore1")`. The line-anchored regex skips
+// keyword-prefixed lines (`Const`, `Dim`, `Sub`, `If`, ...) because they
+// either declare or call rather than bind a string literal.
+static VAR_ASSIGN_REGEX: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"(?im)^\s*([A-Za-z_]\w*)\s*=\s*"([^"]*)"\s*$"#).unwrap());
+
 // Matches `(Load|Save)Value(<arg>, "<score-key>")` for either the modern
 // `HighScoreN` / `HighScoreNName` shape or the legacy EM `hiscore` / `hsa<N>`
 // shape. Captures the section-key argument (an identifier or a quoted
@@ -739,6 +748,14 @@ fn extract_vpreg_section_keys<S: AsRef<str>>(code: S) -> Vec<String> {
         // compile error, but tolerate it just in case.
         consts.entry(id).or_insert(value);
     }
+    // Then fold in plain `<id> = "..."` assignments. Const wins where
+    // there's a conflict (more reliable signal); the assignment path
+    // exists to cover `Dim X` + `X = "..."` scripts like John Wick.
+    for caps in VAR_ASSIGN_REGEX.captures_iter(&stripped) {
+        let id = caps.get(1).unwrap().as_str().to_ascii_lowercase();
+        let value = caps.get(2).unwrap().as_str().to_string();
+        consts.entry(id).or_insert(value);
+    }
 
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut out: Vec<String> = Vec::new();
@@ -1389,6 +1406,33 @@ Const cGameName = "Real"
 y = LoadValue(cGameName, "HighScore1")
 "#;
         assert_eq!(extract_vpreg_section_keys(code), vec!["Real"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_picks_up_dim_plus_assignment() {
+        // John Wick-style: `Dim MyTable` declares the var, separate line
+        // assigns the literal. Used by tables that need to set the section
+        // key dynamically before the Const block (rare but real).
+        let code = r#"
+Dim MyTable
+MyTable = "JPsIT"
+x = LoadValue(MyTable, "HighScore1")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["JPsIT"]);
+    }
+
+    #[test]
+    fn extract_vpreg_keys_const_wins_over_plain_assignment() {
+        // If a script binds the same identifier both as Const and as a
+        // standalone assignment, the Const value is the authoritative one
+        // (VBS would actually reject reassignment of a Const at compile
+        // time, but the regex would otherwise see both).
+        let code = r#"
+Const cGameName = "FromConst"
+cGameName = "FromAssign"
+x = LoadValue(cGameName, "HighScore1")
+"#;
+        assert_eq!(extract_vpreg_section_keys(code), vec!["FromConst"]);
     }
 
     #[test]

--- a/src/scores/vpreg.rs
+++ b/src/scores/vpreg.rs
@@ -140,14 +140,26 @@ fn extract_sections(ini: &Ini, game_name: &str) -> Result<Vec<Section>, LookupEr
 /// Initials decode from `hsa1`/`hsa2`/`hsa3` as 1-indexed positions into
 /// [`LEGACY_EM_ALPHABET`]; missing or out-of-range indices yield an empty
 /// initial slot for that position.
+///
+/// Key lookups are case-insensitive: vpinball persists what the script
+/// writes case-as-typed, so the same script that reads `LoadValue(cGame,
+/// "hsa1")` may end up with `[Section] HSA1=...` on disk (seen on
+/// Star-Jet, A-Go-Go, Time Tunnel). Matching either case lets both
+/// resolve.
 fn try_legacy_em(section: &ini::Properties, game_name: &str) -> Option<Section> {
-    let hiscore: u64 = section.get("hiscore")?.trim().parse().ok()?;
+    // Both spellings are common: `hiscore` (lowercase, contracted - Abra Ca
+    // Dabra, 4 Aces era) and `HighScore` (CamelCase, full word - Star-Jet,
+    // A-Go-Go, Time Tunnel). Try each before giving up.
+    let hiscore: u64 = ["hiscore", "HighScore"]
+        .iter()
+        .find_map(|k| get_ci(section, k))
+        .and_then(|v| v.trim().parse::<u64>().ok())?;
     if hiscore == 0 {
         return None;
     }
     let initials: String = ["hsa1", "hsa2", "hsa3"]
         .iter()
-        .filter_map(|k| section.get(k))
+        .filter_map(|k| get_ci(section, k))
         .filter_map(|v| v.trim().parse::<usize>().ok())
         .filter_map(decode_legacy_em_initial)
         .collect();
@@ -161,6 +173,17 @@ fn try_legacy_em(section: &ini::Properties, game_name: &str) -> Option<Section> 
         ]],
         ranked: false,
     })
+}
+
+/// Case-insensitive lookup against an `ini::Properties` section. The crate
+/// itself only offers case-sensitive access, so we scan keys ourselves.
+/// First match wins (sections with both `HighScore` and `highscore` in the
+/// same section are theoretical only; first-seen is fine).
+fn get_ci<'a>(section: &'a ini::Properties, key: &str) -> Option<&'a str> {
+    section
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(key))
+        .map(|(_, v)| v)
 }
 
 /// Map a 1-indexed `hsa<N>` value to its alphabet character. Returns `None`
@@ -385,6 +408,26 @@ hsa3=38
         );
         let sections = extract_sections(&ini, "em_extended").expect("section");
         assert_eq!(sections[0].rows[0][1], "0_<");
+    }
+
+    #[test]
+    fn legacy_em_matches_uppercase_hsa_and_highscore() {
+        // Real A-Go-Go user/VPReg.ini after a played game: keys are
+        // persisted CamelCase even though the script's LoadValue calls
+        // pass lowercase strings. The parser must case-insensitively
+        // match either casing.
+        let ini = parse(
+            r"
+[A-Go-Go]
+Credits=4
+HSA1=19
+HSA2=15
+HSA3=13
+HighScore=719
+",
+        );
+        let sections = extract_sections(&ini, "A-Go-Go").expect("section");
+        assert_eq!(sections[0].rows[0], vec!["HIGH SCORE", "SOM", "719", ""]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Two adjacent gaps found when bulk-launching unplayed tables to populate VPReg.ini defaults:

1. **Key case-sensitivity**: vpinball writes \`HighScore=\` / \`HSA1=\` etc. on disk regardless of what the script's \`LoadValue\` calls passed. The legacy parser was hard-coded to lowercase \`hiscore\`/\`hsa1\`. Use case-insensitive key lookup and try both \`hiscore\` and \`HighScore\` spellings (different lengths, can't reduce to a single case-insensitive match).

2. **Dim-based section keys**: scripts like John Wick declare \`Dim MyTable\` and assign \`MyTable = "JPsIT"\` rather than using \`Const MyTable = "..."\`. Extend the indexer's section-key extractor to also recognize plain \`<id> = "..."\` assignments. Const declarations still win when both exist.

## Verification
- A-Go-Go (just played): \`HIGH SCORE SOM 719\` (HSA1=19, HSA2=15, HSA3=13 -> "SOM")
- John Wick (batch-launched defaults): \`AAA/BBB/CCC/DDD 100000\` placeholders
- Star-Jet (batch-launched defaults): \`HIGH SCORE WJR 500\`
- Bulk scan: OK 530 -> 541 (+11); no-high-scores bucket 349 -> 338.

## Tests
- 2 new indexer tests (Dim+assignment shape; Const wins on conflict).
- 1 new vpreg test (CamelCase HSA/HighScore decoding).
- 155/155 total tests pass; fmt + clippy clean.

## Dependency
Stacked on #789. Includes the #788 + #789 commits transitively.