### PR TITLE
Drop AV1/AVIF encoder from dependency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,26 +855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,11 +1112,8 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
- "qoi",
  "ravif",
  "rayon",
- "rgb",
- "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -1763,15 +1740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2256,20 +2224,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,17 @@ directb2s = "0.1.1"
 
 edit = "0.1.5"
 pinmame-nvram = "0.4.10"
-image = "0.25.10"
+image = { version = "0.25.10", default-features = false, features = [
+    "bmp",
+    "exr",
+    "gif",
+    "hdr",
+    "jpeg",
+    "png",
+    "tga",
+    "webp",
+    "rayon",
+] }
 num-format = "0.4.4"
 
 #see https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249


### PR DESCRIPTION
## Summary
- vpxtool's `image` dependency used full default features, which enable `avif` -> `ravif` -> `rav1e` (the whole AV1 encoder stack: `rav1e`, `ravif`, `av1-grain`, `av-scenechange`, `v_frame`, ...).
- vpxtool only *decodes* images (`image::load_from_memory` in the frontend, in-memory RGBA work in `backglass.rs`) and never encodes via the `image` crate, so that encoder was dead weight. `vpin` already curates its `image` features correctly - vpxtool was the sole source of the avif feature.
- Set `default-features = false` and match vpin's curated decoder list (`bmp, exr, gif, hdr, jpeg, png, tga, webp, rayon`).

Normal transitive dependencies drop from **222 to 180** (-42 crates); `rav1e` and the AV1 stack are gone.

## Test plan
- [x] `cargo check` builds clean
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` - all 157 tests pass
- [ ] Confirm DMD/backglass image decoding still works at runtime