### PR TITLE
feat(cli): add capture command for playfield screenshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+ "qoi",
  "ravif",
  "rayon",
  "zune-core",
@@ -1737,6 +1738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e790881194f6f6e86945f0a42a6981977323669aeb6c40e9c7ec253133b96f8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ image = { version = "0.25.10", default-features = false, features = [
     "hdr",
     "jpeg",
     "png",
+    "qoi",
     "tga",
     "webp",
     "rayon",

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Commands:
   frontend        Text based frontend for launching vpx files
   simplefrontend  Simple text based frontend for launching vpx files
   index           Indexes a directory of vpx files
+  capture         Capture a playfield screenshot using vpinball
   script          Vpx script code related commands
   ls              Show a vpx file content
   extract         Extracts a vpx file

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,0 +1,446 @@
+use crate::config::ResolvedConfig;
+use crate::describe_exit;
+use image::codecs::jpeg::JpegEncoder;
+use image::imageops::FilterType;
+use image::{ImageFormat, ImageReader};
+use std::fmt::{Display, Formatter};
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+use std::{fs, io, thread};
+
+/// JPEG quality (0-100) used when encoding to jpg.
+const JPEG_QUALITY: u8 = 80;
+
+/// Output image format for a captured playfield screenshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CaptureFormat {
+    /// Lossy, ~15x smaller than png and fast to encode. The default.
+    #[default]
+    Jpg,
+    /// Lossless, large (~10MB at 4K) and slow to encode.
+    Png,
+    /// Lossless WebP via the `image` crate; only marginally smaller than png.
+    Webp,
+    /// vpinball's native capture format, kept as-is (no decode/encode). Lossless
+    /// and instant to save, but ~10MB and read by almost nothing.
+    Qoi,
+}
+
+impl CaptureFormat {
+    /// File extension (without leading dot) used for the generated image.
+    pub fn extension(&self) -> &'static str {
+        match self {
+            CaptureFormat::Png => "png",
+            CaptureFormat::Jpg => "jpg",
+            CaptureFormat::Webp => "webp",
+            CaptureFormat::Qoi => "qoi",
+        }
+    }
+}
+
+impl Display for CaptureFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.extension())
+    }
+}
+
+impl FromStr for CaptureFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "png" => Ok(CaptureFormat::Png),
+            "jpg" | "jpeg" => Ok(CaptureFormat::Jpg),
+            "webp" => Ok(CaptureFormat::Webp),
+            "qoi" => Ok(CaptureFormat::Qoi),
+            other => Err(format!(
+                "Unknown image format '{other}', expected jpg, png, webp or qoi"
+            )),
+        }
+    }
+}
+
+/// Options controlling a screenshot capture run.
+#[derive(Debug, Clone)]
+pub struct CaptureOptions {
+    pub format: CaptureFormat,
+    /// Regenerate the image even if it already exists.
+    pub force: bool,
+    /// Number of frames vpinball captures. The first one is used as the
+    /// screenshot. More than one is rarely useful for a still image.
+    pub frames: u32,
+    /// Capture framerate passed to vpinball (irrelevant for a single frame).
+    pub fps: u32,
+    /// When set, downscale the image so its width does not exceed this many
+    /// pixels (keeping aspect ratio). `None` keeps the native window resolution.
+    pub max_width: Option<u32>,
+    /// Kill vpinball and fail the capture if it runs longer than this, so a
+    /// hanging table does not stall a batch. `None` waits indefinitely.
+    pub timeout: Option<Duration>,
+}
+
+impl Default for CaptureOptions {
+    fn default() -> Self {
+        CaptureOptions {
+            format: CaptureFormat::default(),
+            force: false,
+            frames: 1,
+            fps: 1,
+            max_width: None,
+            timeout: Some(Duration::from_secs(60)),
+        }
+    }
+}
+
+/// Result of a single table capture.
+#[derive(Debug)]
+pub enum CaptureOutcome {
+    /// A new image was written to the given path.
+    Captured(PathBuf),
+    /// vpinball hung and was killed after the timeout, but it had already
+    /// written the frame, so the image was salvaged. The table is slow/flaky.
+    CapturedAfterHang(PathBuf),
+    /// An image already existed and `force` was not set.
+    Skipped(PathBuf),
+}
+
+/// Subfolder (next to the `.vpx`) the playfield image is written into.
+const MEDIA_DIR: &str = "media";
+
+/// Basename used for the playfield image.
+const PLAYFIELD_MEDIA_BASENAME: &str = "table";
+
+/// Path where the playfield screenshot for the given table is written:
+/// `<table dir>/media/table.<ext>`.
+pub fn capture_image_path(vpx_path: &Path, format: CaptureFormat) -> PathBuf {
+    let dir = vpx_path.parent().unwrap_or_else(|| Path::new(""));
+    dir.join(MEDIA_DIR)
+        .join(format!("{PLAYFIELD_MEDIA_BASENAME}.{}", format.extension()))
+}
+
+/// Capture a single playfield screenshot for `vpx_path` using vpinball's
+/// `-CaptureAttract` mode and write it to `<table dir>/media/table.<ext>`.
+///
+/// vpinball renders the playfield into a `Capture/` folder next to the table as
+/// lossless `.qoi` frames, fast-forwarding ~30s of attract play before grabbing
+/// the frame. We convert the first frame to the requested format and clean up.
+pub fn capture_table(
+    config: &ResolvedConfig,
+    vpx_path: &Path,
+    options: &CaptureOptions,
+) -> io::Result<CaptureOutcome> {
+    let output_path = capture_image_path(vpx_path, options.format);
+    if output_path.exists() && !options.force {
+        return Ok(CaptureOutcome::Skipped(output_path));
+    }
+
+    let capture_dir = vpx_path
+        .parent()
+        .map(|p| p.join("Capture"))
+        .unwrap_or_else(|| PathBuf::from("Capture"));
+
+    // Start from a clean slate so we never pick up frames from a previous run.
+    remove_capture_dir(&capture_dir);
+
+    crate::println!("Launching capture for {}", vpx_path.display())?;
+    let started = Instant::now();
+    let run = run_capture(config, vpx_path, options)?;
+    let elapsed = started.elapsed();
+    let timed_out = run.status.is_none();
+
+    // A clean non-zero exit (e.g. a crash) means no usable frame; fail loudly,
+    // reporting the signal when vpinball was killed rather than exiting normally.
+    if let Some(status) = run.status
+        && !status.success()
+    {
+        remove_capture_dir(&capture_dir);
+        return Err(io::Error::other(format!(
+            "vpinball {} while capturing {}{}",
+            describe_exit(status),
+            vpx_path.display(),
+            log_tail(&run.log)
+        )));
+    }
+
+    // On timeout we still try to use the frame: many tables only hang on
+    // shutdown, after the playfield has already been written.
+    let frame = match first_playfield_frame(&capture_dir) {
+        Ok(frame) => frame,
+        Err(e) => {
+            remove_capture_dir(&capture_dir);
+            if timed_out {
+                let secs = options.timeout.map(|t| t.as_secs()).unwrap_or(0);
+                return Err(io::Error::other(format!(
+                    "vpinball did not finish within {secs}s and was terminated before \
+                     capturing a frame for {}{}",
+                    vpx_path.display(),
+                    log_tail(&run.log)
+                )));
+            }
+            return Err(e);
+        }
+    };
+
+    // Ensure the media/ folder exists before writing the image into it.
+    if let Some(parent) = output_path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        remove_capture_dir(&capture_dir);
+        return Err(e);
+    }
+
+    crate::println!(
+        "Capture finished in {:.1}s, converting image",
+        elapsed.as_secs_f32()
+    )?;
+    let convert_result = convert_frame(&frame, &output_path, options.format, options.max_width);
+
+    // Always clean up the intermediate qoi frames, even on conversion errors.
+    remove_capture_dir(&capture_dir);
+    convert_result?;
+
+    let table_file = vpx_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("table");
+    crate::println!(
+        "Capture complete for {} at {}",
+        table_file,
+        output_path.display()
+    )?;
+
+    if timed_out {
+        Ok(CaptureOutcome::CapturedAfterHang(output_path))
+    } else {
+        Ok(CaptureOutcome::Captured(output_path))
+    }
+}
+
+/// Result of a vpinball capture run.
+struct CaptureRun {
+    /// `Some(status)` if vpinball exited on its own; `None` if it hit the
+    /// timeout and we killed it.
+    status: Option<ExitStatus>,
+    /// vpinball's (verbose) stdout/stderr, surfaced only on failure.
+    log: String,
+}
+
+/// Spawn vpinball in capture mode and wait for it to exit (or be killed after
+/// the timeout). vpinball's verbose stdout/stderr is redirected to a temp file
+/// (avoiding pipe-buffer deadlocks if it stalls mid-output) and read back so the
+/// caller can surface a tail on failure.
+fn run_capture(
+    config: &ResolvedConfig,
+    vpx_path: &Path,
+    options: &CaptureOptions,
+) -> io::Result<CaptureRun> {
+    let log_path = std::env::temp_dir().join(format!("vpxtool-capture-{}.log", std::process::id()));
+    let log_file = File::create(&log_path)?;
+    let log_file_err = log_file.try_clone()?;
+
+    let mut cmd = Command::new(&config.vpx_executable);
+    // Reuse the environment from the first launch template (e.g. SDL_VIDEO_DRIVER
+    // on Wayland) so capture behaves like a normal launch.
+    if let Some(env) = config.launch_templates.first().and_then(|t| t.env.as_ref()) {
+        for (key, value) in env.iter() {
+            cmd.env(key, value);
+        }
+    }
+    cmd.arg("-Ini");
+    cmd.arg(&config.vpx_config);
+    // -CaptureAttract <frames> <fps> <table> noloop
+    cmd.arg("-CaptureAttract");
+    cmd.arg(options.frames.to_string());
+    cmd.arg(options.fps.to_string());
+    cmd.arg(vpx_path);
+    cmd.arg("noloop");
+    cmd.stdout(Stdio::from(log_file));
+    cmd.stderr(Stdio::from(log_file_err));
+
+    let mut child = cmd.spawn()?;
+    let status = wait_with_timeout(&mut child, options.timeout)?;
+
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    let _ = fs::remove_file(&log_path);
+    Ok(CaptureRun { status, log })
+}
+
+/// Wait for the child to exit, polling so we can kill it once `timeout` elapses.
+/// Returns `Ok(None)` if it was killed for exceeding the timeout.
+fn wait_with_timeout(
+    child: &mut Child,
+    timeout: Option<Duration>,
+) -> io::Result<Option<ExitStatus>> {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
+        }
+        if let Some(timeout) = timeout
+            && start.elapsed() >= timeout
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(None);
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Keep only the last few lines of vpinball output for an error message,
+/// prefixed with a blank line, or an empty string when there is nothing.
+fn log_tail(output: &str) -> String {
+    let lines: Vec<&str> = output.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return String::new();
+    }
+    let start = lines.len().saturating_sub(10);
+    format!("\n{}", lines[start..].join("\n"))
+}
+
+/// Find the lowest-indexed `Playfield_*.qoi` frame in the capture folder.
+fn first_playfield_frame(capture_dir: &Path) -> io::Result<PathBuf> {
+    if !capture_dir.is_dir() {
+        return Err(io::Error::other(format!(
+            "vpinball did not produce a capture folder at {}",
+            capture_dir.display()
+        )));
+    }
+    let mut frames: Vec<PathBuf> = fs::read_dir(capture_dir)?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| is_playfield_frame(p))
+        .collect();
+    frames.sort();
+    frames.into_iter().next().ok_or_else(|| {
+        io::Error::other(format!(
+            "no playfield frame found in {}",
+            capture_dir.display()
+        ))
+    })
+}
+
+/// Whether the path is a `Playfield_*.qoi` frame written by vpinball. The
+/// `noloop` capture keeps a `_tmp` suffix, so match on the prefix and extension.
+fn is_playfield_frame(path: &Path) -> bool {
+    let is_qoi = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("qoi"));
+    let is_playfield = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with("Playfield_"));
+    is_qoi && is_playfield
+}
+
+/// Write the captured qoi frame to `output_path` in the requested format,
+/// optionally downscaling first.
+fn convert_frame(
+    frame: &Path,
+    output_path: &Path,
+    format: CaptureFormat,
+    max_width: Option<u32>,
+) -> io::Result<()> {
+    // qoi: keep vpinball's native frame as-is, no decode/encode (max_width does
+    // not apply since we never decode it).
+    if format == CaptureFormat::Qoi {
+        fs::copy(frame, output_path)?;
+        return Ok(());
+    }
+
+    let mut image = ImageReader::open(frame)?
+        .with_guessed_format()?
+        .decode()
+        .map_err(|e| io::Error::other(format!("Unable to decode {}: {e}", frame.display())))?;
+
+    // Downscale (never upscale) so the width fits max_width, keeping aspect ratio.
+    if let Some(max_width) = max_width
+        && image.width() > max_width
+    {
+        let height =
+            ((image.height() as u64 * max_width as u64) / image.width() as u64).max(1) as u32;
+        image = image.resize(max_width, height, FilterType::Lanczos3);
+    }
+
+    let write_err = |e| io::Error::other(format!("Unable to write {}: {e}", output_path.display()));
+    match format {
+        // png and webp keep the alpha channel as captured.
+        CaptureFormat::Png => image
+            .save_with_format(output_path, ImageFormat::Png)
+            .map_err(write_err),
+        CaptureFormat::Webp => image
+            .save_with_format(output_path, ImageFormat::WebP)
+            .map_err(write_err),
+        // jpeg has no alpha channel, so drop it first; encode at JPEG_QUALITY.
+        CaptureFormat::Jpg => {
+            let rgb = image.to_rgb8();
+            let mut writer = BufWriter::new(File::create(output_path)?);
+            JpegEncoder::new_with_quality(&mut writer, JPEG_QUALITY)
+                .encode_image(&rgb)
+                .map_err(write_err)
+        }
+        CaptureFormat::Qoi => unreachable!("qoi handled above"),
+    }
+}
+
+fn remove_capture_dir(capture_dir: &Path) {
+    if capture_dir.exists() {
+        // Best effort: leftover frames are harmless and a failure here should
+        // not mask the capture result.
+        let _ = fs::remove_dir_all(capture_dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capture_format_from_str() {
+        assert_eq!(CaptureFormat::from_str("png"), Ok(CaptureFormat::Png));
+        assert_eq!(CaptureFormat::from_str("PNG"), Ok(CaptureFormat::Png));
+        assert_eq!(CaptureFormat::from_str("jpg"), Ok(CaptureFormat::Jpg));
+        assert_eq!(CaptureFormat::from_str("jpeg"), Ok(CaptureFormat::Jpg));
+        assert_eq!(CaptureFormat::from_str("webp"), Ok(CaptureFormat::Webp));
+        assert_eq!(CaptureFormat::from_str("WebP"), Ok(CaptureFormat::Webp));
+        assert_eq!(CaptureFormat::from_str("qoi"), Ok(CaptureFormat::Qoi));
+        assert!(CaptureFormat::from_str("gif").is_err());
+    }
+
+    #[test]
+    fn test_capture_image_path() {
+        // table.<ext> next to the vpx, named "table" regardless of the vpx
+        // filename (vpinfe-compatible via its table-dir fallback).
+        let vpx = Path::new("/tables/Foo (Bar 1999)/Foo (Bar 1999).vpx");
+        assert_eq!(
+            capture_image_path(vpx, CaptureFormat::Png),
+            PathBuf::from("/tables/Foo (Bar 1999)/media/table.png")
+        );
+        assert_eq!(
+            capture_image_path(vpx, CaptureFormat::Jpg),
+            PathBuf::from("/tables/Foo (Bar 1999)/media/table.jpg")
+        );
+    }
+
+    #[test]
+    fn test_capture_image_path_no_parent() {
+        let vpx = Path::new("Foo.vpx");
+        assert_eq!(
+            capture_image_path(vpx, CaptureFormat::Png),
+            PathBuf::from("media/table.png")
+        );
+    }
+
+    #[test]
+    fn test_is_playfield_frame() {
+        assert!(is_playfield_frame(Path::new("/c/Playfield_00001_tmp.qoi")));
+        assert!(is_playfield_frame(Path::new("/c/Playfield_00001.qoi")));
+        assert!(!is_playfield_frame(Path::new("/c/Backglass_00001.qoi")));
+        assert!(!is_playfield_frame(Path::new("/c/Playfield_00001.png")));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::capture::{CaptureFormat, CaptureOptions, CaptureOutcome, capture_table};
 use crate::config::{ResolvedConfig, SetupConfigResult};
 use crate::indexer::{DEFAULT_INDEX_FILE_NAME, IndexError, Progress};
 use crate::patcher::patch_vbs_file;
@@ -22,7 +23,7 @@ use std::io;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{ExitCode, exit};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use vpin::filesystem::RealFileSystem;
 use vpin::vpx;
 use vpin::vpx::expanded::ExpandOptions;
@@ -41,6 +42,7 @@ const GIT_VERSION: &str = git_version!(
 
 const OK: Emoji = Emoji("✅", "[launch]");
 const NOK: Emoji = Emoji("❌", "[crash]");
+const WARN: Emoji = Emoji("⚠️", "[warn]");
 
 const CMD_FRONTEND: &str = "frontend";
 const CMD_DIFF: &str = "diff";
@@ -121,8 +123,15 @@ const CMD_EXPORT_GLTF: &str = "gltf";
 const CMD_EXPORT_VPXZ: &str = "vpxz";
 
 const CMD_INDEX: &str = "index";
+
+const CMD_CAPTURE: &str = "capture";
+
 const ARG_VERBOSE: &str = "VERBOSE";
 const ARG_MAX_DEPTH: &str = "MAX_DEPTH";
+const ARG_FORCE: &str = "FORCE";
+const ARG_FORMAT: &str = "FORMAT";
+const ARG_MAX_WIDTH: &str = "MAX_WIDTH_PX";
+const ARG_TIMEOUT: &str = "TIMEOUT_SECS";
 
 pub(crate) struct ProgressBarProgress {
     pb: ProgressBar,
@@ -331,6 +340,7 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             }
         }
         Some((CMD_INDEX, sub_matches)) => handle_index(sub_matches),
+        Some((CMD_CAPTURE, sub_matches)) => handle_capture(sub_matches),
         Some((CMD_SCRIPT, sub_matches)) => match sub_matches.subcommand() {
             Some((CMD_SCRIPT_SHOW, sub_matches)) => {
                 let path = sub_matches
@@ -873,6 +883,137 @@ fn handle_index(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
+fn handle_capture(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
+    let force = sub_matches.get_flag(ARG_FORCE);
+    let format = sub_matches
+        .get_one::<String>(ARG_FORMAT)
+        .map(|s| s.parse::<CaptureFormat>())
+        .transpose()
+        .map_err(io::Error::other)?
+        .unwrap_or_default();
+    let max_width = sub_matches.get_one::<u32>(ARG_MAX_WIDTH).copied();
+    let timeout = sub_matches
+        .get_one::<u64>(ARG_TIMEOUT)
+        .copied()
+        .filter(|&s| s > 0)
+        .map(Duration::from_secs);
+    let options = CaptureOptions {
+        format,
+        force,
+        max_width,
+        timeout,
+        ..CaptureOptions::default()
+    };
+
+    let (config_path, config) = config::load_or_setup_config()?;
+    crate::println!("Using vpxtool config file {}", config_path.display())?;
+
+    if !config.vpx_executable.is_file() {
+        crate::eprintln!(
+            "{}",
+            format!(
+                "vpinball executable not found at {}",
+                config.vpx_executable.display()
+            )
+            .red()
+        )?;
+        return Ok(ExitCode::FAILURE);
+    }
+
+    // Single table.
+    if let Some(vpx_path_arg) = sub_matches.get_one::<String>("VPXPATH") {
+        let vpx_path = path_exists(vpx_path_arg)?;
+        return match capture_table(&config, &vpx_path, &options) {
+            Ok(CaptureOutcome::Captured(_)) => Ok(ExitCode::SUCCESS),
+            Ok(CaptureOutcome::CapturedAfterHang(path)) => {
+                crate::eprintln!(
+                    "{}",
+                    format!(
+                        "{WARN} vpinball hung and was killed; salvaged frame for {}",
+                        path.display()
+                    )
+                    .yellow()
+                )?;
+                Ok(ExitCode::SUCCESS)
+            }
+            Ok(CaptureOutcome::Skipped(path)) => {
+                crate::println!(
+                    "Skipping, {} already exists (use --force to regenerate)",
+                    path.display()
+                )?;
+                Ok(ExitCode::SUCCESS)
+            }
+            Err(e) => {
+                crate::eprintln!("{}", format!("{NOK} Capture failed: {e}").red())?;
+                Ok(ExitCode::FAILURE)
+            }
+        };
+    }
+
+    // Batch over all tables in the configured tables folder.
+    let configured_pinmame_folder = config.configured_pinmame_folder();
+    let tables = match frontend::frontend_index(
+        &config,
+        true,
+        config.tables_scan_max_depth,
+        configured_pinmame_folder.as_deref(),
+        vec![],
+    ) {
+        Ok(tables) => tables,
+        Err(e) => {
+            crate::eprintln!("{}", format!("Unable to index tables: {e:?}").red())?;
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    crate::println!(
+        "Capturing {} screenshots for {} tables in {}",
+        format,
+        tables.len(),
+        config.tables_folder.display()
+    )?;
+
+    let mut captured = 0;
+    let mut hung = 0;
+    let mut skipped = 0;
+    let mut failed = 0;
+    for table in &tables {
+        match capture_table(&config, &table.path, &options) {
+            Ok(CaptureOutcome::Captured(_)) => {
+                captured += 1;
+            }
+            Ok(CaptureOutcome::CapturedAfterHang(path)) => {
+                hung += 1;
+                captured += 1;
+                crate::eprintln!(
+                    "{}",
+                    format!(
+                        "{WARN} vpinball hung and was killed; salvaged frame for {}",
+                        path.display()
+                    )
+                    .yellow()
+                )?;
+            }
+            Ok(CaptureOutcome::Skipped(_)) => {
+                skipped += 1;
+            }
+            Err(e) => {
+                failed += 1;
+                crate::eprintln!("{}", format!("{NOK} {}: {e}", table.path.display()).red())?;
+            }
+        }
+    }
+
+    crate::println!(
+        "Done. {captured} captured ({hung} after a hang), {skipped} skipped, {failed} failed."
+    )?;
+    if failed > 0 {
+        Ok(ExitCode::FAILURE)
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
 fn build_command() -> Command {
     // to allow for non-static strings in clap
     // I had to enable the "string" module
@@ -991,6 +1132,47 @@ fn build_command() -> Command {
                 .arg(
                     arg!(<INDEX_FILE> "Where the index will be written. Defaults to VPXROOTPATH/vpxtool_index.json.")
                         .required(false)
+                ),
+        )
+        .subcommand(
+            Command::new(CMD_CAPTURE)
+                .about("Capture a playfield screenshot using vpinball")
+                .long_about(
+                    "Capture a playfield screenshot next to the table using vpinball's \
+                     attract capture mode. With a VPXPATH a single table is captured, \
+                     otherwise every table in the configured tables folder is captured, \
+                     skipping tables that already have an image unless --force is given.",
+                )
+                .arg(
+                    arg!([VPXPATH] "The path to a single vpx file. Defaults to capturing all tables in the configured tables folder.")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new(ARG_FORCE)
+                        .short('f')
+                        .long("force")
+                        .num_args(0)
+                        .help("Regenerate the image even if it already exists"),
+                )
+                .arg(
+                    Arg::new(ARG_FORMAT)
+                        .long("format")
+                        .value_parser(["jpg", "png", "webp", "qoi"])
+                        .default_value("jpg")
+                        .help("Output image format. jpg (quality 80) is the small, fast default; png/webp are lossless but ~15x larger and slower to encode; qoi keeps vpinball's raw frame (lossless, instant, but ~10MB and barely supported)."),
+                )
+                .arg(
+                    Arg::new(ARG_MAX_WIDTH)
+                        .long("max-width")
+                        .value_parser(clap::value_parser!(u32))
+                        .help("Downscale the image so its width does not exceed this many pixels (keeps aspect ratio). Defaults to the native vpinball playfield window resolution."),
+                )
+                .arg(
+                    Arg::new(ARG_TIMEOUT)
+                        .long("timeout")
+                        .value_parser(clap::value_parser!(u64))
+                        .default_value("60")
+                        .help("Kill vpinball and skip the table if a capture takes longer than this many seconds (0 disables the timeout). Prevents a hanging table from stalling a batch."),
                 ),
         )
         .subcommand(

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -1,4 +1,5 @@
 use crate::backglass::find_hole;
+use crate::capture::{CaptureOptions, CaptureOutcome, capture_table};
 use crate::cli::{
     DiffColor, ProgressBarProgress, confirm, info_diff, info_edit, info_gather, open_editor,
     run_diff, script_diff,
@@ -9,7 +10,7 @@ use crate::indexer::{IndexError, IndexedTable, Progress};
 use crate::patcher::LineEndingsResult::{NoChanges, Unified};
 use crate::patcher::{patch_vbs_file, unify_line_endings_vbs_file};
 use crate::vpinball_config::{VPinballConfig, WindowInfo, WindowType};
-use crate::{indexer, strip_cr_lf};
+use crate::{describe_exit, indexer, strip_cr_lf, was_killed_by_signal};
 use base64::Engine;
 use colored::Colorize;
 use console::{Emoji, Term};
@@ -58,6 +59,7 @@ enum TableOption {
     EditTableINI,
     EditMainIni,
     ExportVpxz,
+    CaptureScreenshot,
 }
 
 impl TableOption {
@@ -88,6 +90,7 @@ impl TableOption {
             TableOption::EditTableINI,
             TableOption::EditMainIni,
             TableOption::ExportVpxz,
+            TableOption::CaptureScreenshot,
         ]);
         options
     }
@@ -114,6 +117,7 @@ impl TableOption {
             TableOption::EditTableINI => "INI > Edit table ini".to_string(),
             TableOption::EditMainIni => "INI > Edit main ini".to_string(),
             TableOption::ExportVpxz => "Export > vpxz (mobile)".to_string(),
+            TableOption::CaptureScreenshot => "Capture > Playfield screenshot".to_string(),
         }
     }
 }
@@ -495,6 +499,26 @@ fn table_menu(
                 Ok(msg) => prompt(&msg),
                 Err(err) => prompt_error(&format!("Unable to export vpxz: {err}")),
             },
+            Some(TableOption::CaptureScreenshot) => {
+                // Explicit user action, so always regenerate.
+                let options = CaptureOptions {
+                    force: true,
+                    ..CaptureOptions::default()
+                };
+                match capture_table(config, selected_path, &options) {
+                    Ok(CaptureOutcome::Captured(path)) => {
+                        prompt(&format!("Captured screenshot to {}", path.display()))
+                    }
+                    Ok(CaptureOutcome::CapturedAfterHang(path)) => prompt(&format!(
+                        "vpinball hung and was killed, but the screenshot was salvaged to {}",
+                        path.display()
+                    )),
+                    Ok(CaptureOutcome::Skipped(path)) => {
+                        prompt(&format!("Screenshot already exists at {}", path.display()))
+                    }
+                    Err(err) => prompt_error(&format!("Unable to capture screenshot: {err}")),
+                }
+            }
             None => exit = true,
         }
     }
@@ -902,27 +926,21 @@ fn launch(selected_path: &PathBuf, launch_template: &LaunchTemplate) {
     }
 
     match launch_table(selected_path, launch_template) {
-        Ok(status) => match status.code() {
-            Some(0) => {
-                Term::stderr().clear_screen().ok();
-            }
-            Some(11) => {
+        Ok(status) if status.success() => {
+            Term::stderr().clear_screen().ok();
+        }
+        Ok(status) => {
+            // A crash kills the process with a signal (SIGSEGV/SIGABRT/...), which
+            // has no exit code; describe_exit names the signal in that case.
+            if was_killed_by_signal(status) {
                 prompt(&format!(
-                    "{CRASH} Visual Pinball exited with segfault, you might want to report this to the vpinball team."
+                    "{CRASH} Visual Pinball {}, you might want to report this to the vpinball team.",
+                    describe_exit(status)
                 ));
+            } else {
+                prompt(&format!("{CRASH} Visual Pinball {}", describe_exit(status)));
             }
-            Some(139) => {
-                prompt(&format!(
-                    "{CRASH} Visual Pinball exited with segfault, you might want to report this to the vpinball team."
-                ));
-            }
-            Some(code) => {
-                prompt(&format!("{CRASH} Visual Pinball exited with code {code}"));
-            }
-            None => {
-                prompt("Visual Pinball exited with unknown code");
-            }
-        },
+        }
         Err(e) => {
             if e.kind() == io::ErrorKind::NotFound {
                 report_and_exit(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 use std::fs::metadata;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::process::ExitStatus;
 
 mod atomicwrite;
 mod backglass;
+pub mod capture;
 pub mod fixprint;
 mod frontend;
 pub mod patcher;
@@ -17,6 +19,49 @@ mod colorful_theme_patched;
 pub mod scores;
 pub mod vpinball_config;
 pub mod vpxz;
+
+/// Human-readable description of how a child process ended, naming the signal
+/// when it was killed (e.g. a segfault) rather than exiting with a code. On Unix
+/// a signal death has no exit code (`ExitStatus::code()` is `None`), which is why
+/// an unhandled crash otherwise shows up as an "unknown" exit.
+pub(crate) fn describe_exit(status: ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("exited with code {code}");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            let name = match signal {
+                2 => " (SIGINT)",
+                4 => " (SIGILL)",
+                6 => " (SIGABRT)",
+                8 => " (SIGFPE)",
+                9 => " (SIGKILL)",
+                11 => " (SIGSEGV, crash)",
+                15 => " (SIGTERM)",
+                _ => "",
+            };
+            return format!("was killed by signal {signal}{name}");
+        }
+    }
+    "exited with an unknown status".to_string()
+}
+
+/// Whether the process was terminated by a signal (e.g. crashed) rather than
+/// exiting on its own. Always `false` on non-Unix platforms.
+pub(crate) fn was_killed_by_signal(status: ExitStatus) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal().is_some()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = status;
+        false
+    }
+}
 
 pub fn strip_cr_lf(s: &str) -> String {
     s.chars().filter(|c| !c.is_ascii_whitespace()).collect()
@@ -77,6 +122,22 @@ impl Drop for RemoveOnDrop {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn test_describe_exit_reports_signal() {
+        use std::os::unix::process::ExitStatusExt;
+        // Killed by SIGSEGV (a crash) -> no exit code, report the signal.
+        let crashed = ExitStatus::from_raw(11);
+        let desc = describe_exit(crashed);
+        assert!(desc.contains("signal 11"), "{desc}");
+        assert!(desc.contains("SIGSEGV"), "{desc}");
+        assert!(was_killed_by_signal(crashed));
+        // Normal exit with a code.
+        let exited = ExitStatus::from_raw(2 << 8);
+        assert_eq!(describe_exit(exited), "exited with code 2");
+        assert!(!was_killed_by_signal(exited));
+    }
 
     #[test]
     fn test_os_independent_file_name_windows() {


### PR DESCRIPTION
Adds `vpxtool capture` which uses vpinball's attract capture mode to write a playfield screenshot to <table dir>/media/table.<ext>, for a single table or in batch (skipping existing, --force to regenerate). Supports jpg (default, q80), png, webp and qoi, --max-width downscaling, and a --timeout that kills a hung vpinball, salvaging the frame if one was already written. Also unifies vpinball exit-status reporting to name the killing signal.