### PR TITLE
chore: set dependabot cargo versioning-strategy to increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Always bump the version in Cargo.toml instead of doing lockfile-only
+    # updates for in-range versions. Lockfile-only bumps are invisible to
+    # release-plz, which decides the changelog range by comparing packaged
+    # files (Cargo.lock is not one of them), so those bumps were missing
+    # from release changelogs even when they mattered for the shipped
+    # binaries (e.g. the vpin 0.26.10 panic fixes).
+    versioning-strategy: "increase"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot's default strategy for cargo does lockfile-only updates when the new version still satisfies the Cargo.toml requirement. Those bumps are invisible to release-plz, which scopes changelog commits to files of the crate and compares packaged files against the published release, so lockfile-only bumps were missing from release changelogs (see #834, where the vpin 0.26.10 bump with the panic fixes from #826 was dropped) and would not trigger a release on their own.

With `versioning-strategy: increase` every Dependabot update bumps the version in Cargo.toml, so the bumps show up in release-plz changelogs and correctly mark the release boundary.

The proper upstream fix would be a release-plz option to consider Cargo.lock changes, tracked in https://github.com/release-plz/release-plz/issues/2852. This config change works today and can be reverted if that lands.