### PR TITLE
chore: require vpin 0.26.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.26.4" }
+vpin = { version = "0.26.10" }
 directb2s = "0.1.1"
 
 edit = "0.1.5"


### PR DESCRIPTION
Fixes #826

Raises the vpin requirement in Cargo.toml to 0.26.10, the release that handles unknown GateType values instead of panicking (francisdb/vpin#334, fixed in francisdb/vpin#335). Cargo.lock was already on 0.26.10 via #832, but that lockfile-only bump was invisible to release-plz (see #835); making the requirement explicit guarantees the fix for builds from source and puts it in the release changelog.

This resolves the five reported table failures (Algar, Asteroid Annie, Fireball II, Lethal Weapon 3, Tri Zone). The broader work of removing the remaining panic sites in vpin's .vpx parsing is tracked in francisdb/vpin#337.