### PR TITLE
fix(frontend): handle unsupported NVRAM DIP switch maps

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -534,8 +534,12 @@ fn nvram_dip_switches(info: &IndexedTable) {
                     // ok
                 }
                 Err(err) => {
-                    let msg = format!("Unable to edit DIP switches: {err}");
-                    prompt_error(&msg);
+                    if err.kind() == io::ErrorKind::Unsupported {
+                        prompt(&err.to_string());
+                    } else {
+                        let msg = format!("Unable to edit DIP switches: {err}");
+                        prompt_error(&msg);
+                    }
                 }
             }
         } else {
@@ -690,7 +694,12 @@ fn auto_position_dmd(config: &ResolvedConfig, info: &&IndexedTable) -> Result<St
 }
 
 fn edit_dip_switches(nvram: PathBuf) -> io::Result<()> {
-    let nvram_map = Nvram::open(Path::new(&nvram))?.unwrap();
+    let nvram_map = Nvram::open(Path::new(&nvram))?.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("{} currently not supported", nvram.display()),
+        )
+    })?;
     let disp_info = nvram_map.dip_switches_info()?;
     let mut nvram_file = OpenOptions::new().read(true).write(true).open(nvram)?;
     let mut switches = get_all_dip_switches(&mut nvram_file)?;


### PR DESCRIPTION
## Summary
- prevent panic in NVRAM DIP switch editor when pinmame-nvram has no map for a ROM
- handle Nvram::open(...) returning None as an unsupported case
- align UX with NVRAM Show by displaying "<path> currently not supported"

## Why
Selecting NVRAM > DIP Switches for some tables (for example [Black Sheep Squadron (Astro Games 1979)](https://virtualpinballspreadsheet.github.io/games?game=OxHnb-rI)) could panic due to unwrap() on a None map result.

## Validation
- cargo test -q
