### PR TITLE
fix(frontend): unify line endings before diffing VBScript

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::capture::{CaptureFormat, CaptureOptions, CaptureOutcome, capture_table};
 use crate::config::{ResolvedConfig, SetupConfigResult};
 use crate::indexer::{DEFAULT_INDEX_FILE_NAME, IndexError, Progress};
-use crate::patcher::patch_vbs_file;
+use crate::patcher::{patch_vbs_file, unify_line_endings};
 use crate::{
     RemoveOnDrop, config, frontend, indexer, os_independent_file_name, path_exists, strip_cr_lf,
 };
@@ -3079,6 +3079,7 @@ pub fn info_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io::R
         let output = run_diff(
             original_info_path.path(),
             &info_file_path,
+            &info_file_path,
             diff_color,
             config,
         )?;
@@ -3099,13 +3100,30 @@ pub fn script_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io:
                 let script = gamedata.code;
                 let original_vbs_path =
                     RemoveOnDrop::new(vpx_file_path.with_extension("vbs.original.tmp"));
-                std::fs::write(original_vbs_path.path(), script.string)?;
+                // Unify line endings to CRLF so that diff doesn't show
+                // spurious changes when the VPX-embedded script uses different
+                // line terminators than the sidecar .vbs file on disk.
+                let normalized_original = unify_line_endings(&script.string);
+                std::fs::write(original_vbs_path.path(), normalized_original)?;
+
+                let modified_vbs_path =
+                    RemoveOnDrop::new(vpx_file_path.with_extension("vbs.modified.tmp"));
+                let sidecar_content = std::fs::read_to_string(&vbs_path)?;
+                let normalized_modified = unify_line_endings(&sidecar_content);
+                std::fs::write(modified_vbs_path.path(), normalized_modified)?;
+
                 let diff_color = if colored::control::SHOULD_COLORIZE.should_colorize() {
                     DiffColor::Always
                 } else {
                     DiffColor::Never
                 };
-                let output = run_diff(original_vbs_path.path(), &vbs_path, diff_color, config)?;
+                let output = run_diff(
+                    original_vbs_path.path(),
+                    modified_vbs_path.path(),
+                    &vbs_path,
+                    diff_color,
+                    config,
+                )?;
                 Ok(String::from_utf8_lossy(&output).to_string())
             }
             Err(e) => {
@@ -3138,6 +3156,7 @@ impl DiffColor {
 pub fn run_diff(
     original_vbs_path: &Path,
     vbs_path: &Path,
+    vbs_label_path: &Path,
     color: DiffColor,
     config: Option<&ResolvedConfig>,
 ) -> Result<Vec<u8>, io::Error> {
@@ -3145,6 +3164,9 @@ pub fn run_diff(
         .file_name()
         .unwrap_or(original_vbs_path.as_os_str());
     let original_vbs_file_name_no_tmp = original_vbs_filename.to_string_lossy().replace(".tmp", "");
+    let vbs_label_filename = vbs_label_path
+        .file_name()
+        .unwrap_or(vbs_label_path.as_os_str());
     let vbs_filename = vbs_path.file_name().unwrap_or(vbs_path.as_os_str());
     let diff = config
         .and_then(|resolved| resolved.diff.as_deref())
@@ -3162,7 +3184,7 @@ pub fn run_diff(
         .arg(format!("--color={}", color.to_diff_arg()))
         .arg(format!("--label={original_vbs_file_name_no_tmp}"))
         .arg(original_vbs_filename)
-        .arg(format!("--label={}", vbs_filename.to_string_lossy()))
+        .arg(format!("--label={}", vbs_label_filename.to_string_lossy()))
         .arg(vbs_filename);
     info!("Running command: {:?}", command);
     let result = command.output().map(|o| o.stdout);

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -410,7 +410,13 @@ fn table_menu(
                 let vbs_path = vbs_path_for(selected_path);
                 let patch_path = vbs_path.with_extension("vbs.patch");
 
-                match run_diff(&original_path, &vbs_path, DiffColor::Never, Some(config)) {
+                match run_diff(
+                    &original_path,
+                    &vbs_path,
+                    &vbs_path,
+                    DiffColor::Never,
+                    Some(config),
+                ) {
                     Ok(diff) => {
                         let mut file = File::create(patch_path).unwrap();
                         file.write_all(&diff).unwrap();

--- a/src/patcher.rs
+++ b/src/patcher.rs
@@ -85,7 +85,7 @@ pub fn patch_script(script: String) -> (String, HashSet<PatchType>) {
     (patched_script, applied_patches)
 }
 
-fn unify_line_endings(script: &str) -> String {
+pub fn unify_line_endings(script: &str) -> String {
     // first replace all \r\n with \n
     // then replace all \r with \n (this is the main issue, as some files have mixed \r\n and \r)
     // then go back to standard vbs line endings \r\n

--- a/tests/script_diff_line_endings.rs
+++ b/tests/script_diff_line_endings.rs
@@ -1,0 +1,105 @@
+//! Verify that `script diff` normalizes line endings so that differences
+//! in CR/LF style alone don't produce spurious output.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use testdir::testdir;
+
+fn vpxtool(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_vpxtool"))
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vpxtool")
+        .wait_with_output()
+        .expect("failed to wait for vpxtool")
+}
+
+/// When the sidecar .vbs differs from the VPX-embedded script only in line
+/// endings (a mix of CRLF, bare CR, and bare LF — matching the real-world
+/// scenario from tables like Mustang LE), `script diff` should produce no
+/// output.
+#[test]
+fn script_diff_ignores_mixed_line_ending_differences() {
+    let dir = testdir!();
+
+    // Create a minimal VPX.
+    let vpx_path = dir.join("table.vpx");
+    let out = vpxtool(&dir, &["new", "table.vpx"]);
+    assert!(out.status.success(), "vpxtool new failed: {:?}", out);
+
+    // Extract the embedded script as a sidecar .vbs.
+    let out = vpxtool(&dir, &["script", "extract", "table.vpx"]);
+    assert!(
+        out.status.success(),
+        "vpxtool script extract failed: {:?}",
+        out
+    );
+
+    // Read the sidecar and rebuild it with a mix of line endings:
+    // some lines use bare CR, some use bare LF, the rest stay as CRLF.
+    // This mirrors real tables where editors or copy-paste introduced
+    // inconsistent terminators into the VBS script.
+    let vbs_path = vpx_path.with_extension("vbs");
+    let original = std::fs::read_to_string(&vbs_path).expect("read vbs");
+    let lines: Vec<&str> = original.lines().collect();
+    let mut mixed = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        mixed.push_str(line);
+        match i % 3 {
+            0 => mixed.push_str("\r\n"), // CRLF (standard)
+            1 => mixed.push('\r'),       // bare CR (the problematic case)
+            _ => mixed.push('\n'),       // bare LF
+        }
+    }
+    std::fs::write(&vbs_path, &mixed).expect("write vbs");
+
+    // script diff should see no semantic difference.
+    let out = vpxtool(&dir, &["script", "diff", "table.vpx"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "script diff exited with failure: {:?}\nstderr: {stderr}",
+        out.status,
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "expected no diff output when only line endings differ, got:\n{stdout}"
+    );
+}
+
+/// When the sidecar .vbs has a real content change on top of line-ending
+/// differences, `script diff` should still report that change.
+#[test]
+fn script_diff_reports_real_changes_despite_mixed_endings() {
+    let dir = testdir!();
+
+    let vpx_path = dir.join("table.vpx");
+    let out = vpxtool(&dir, &["new", "table.vpx"]);
+    assert!(out.status.success(), "vpxtool new failed: {:?}", out);
+
+    let out = vpxtool(&dir, &["script", "extract", "table.vpx"]);
+    assert!(
+        out.status.success(),
+        "vpxtool script extract failed: {:?}",
+        out
+    );
+
+    // Modify the sidecar: convert to LF and append a new line of code.
+    let vbs_path = vpx_path.with_extension("vbs");
+    let original = std::fs::read_to_string(&vbs_path).expect("read vbs");
+    let mut modified = original.replace("\r\n", "\n").replace('\r', "\n");
+    modified.push_str("' added comment\n");
+    std::fs::write(&vbs_path, &modified).expect("write vbs");
+
+    let out = vpxtool(&dir, &["script", "diff", "table.vpx"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("added comment"),
+        "expected diff to contain the real change, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Problem

"VBScript > Diff" produces garbled output on Windows when the VPX-embedded script contains mixed line endings (CRLF + bare CR + bare LF).

The issue was discovered with [Mustang (Limited Edition) (Stern 2014)](https://virtualpinballspreadsheet.github.io/games?game=gevaj3sH), specifically table [onQP6yte8Z](https://vpuniverse.com/files/file/26079-mustang-stern-2014-cabinet-mod/) (patched table [7xfv56UA5s](https://vpuniverse.com/files/file/16314-mustang-stern-2014/)). The VPX-embedded script has 103 bare CR characters, which cause `diff` to treat those regions as single long lines, producing a mashup of unrelated content.

On Mac the system `diff` handles bare CR differently, so the output appeared correct there but not on Windows.

## Root cause

- The VPX stores the script with mixed line endings (4318 CRLF + 3 bare LF + 103 bare CR)
- `extractvbs` writes the script as-is, preserving the mixed endings
- Opening in VS Code and saving normalizes the sidecar `.vbs` to clean CRLF
- `script_diff` compared the raw VPX-embedded bytes against the clean sidecar without any normalization
- The `-w` flag on `diff` does not handle bare CR as a line separator

## Fix

Call `unify_line_endings` (already existed in `patcher.rs` for the "Unify line endings" menu option) on both files before passing them to `diff`. This ensures both sides have consistent CRLF line endings regardless of what's stored in the VPX.

Applied to both `ShowVBSDiff` and `CreateVBSPatch` code paths.

## Future consideration

It might be worth auto-unifying line endings during `extractvbs` itself and dropping the separate "VBScript > Unify line endings" menu option. That would prevent the mismatch from ever occurring. This change would still be necessary regardless, since the VPX-embedded original is always read fresh for comparison.