### PR TITLE
build: replace unmaintained jwalk with ignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,28 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,15 +615,6 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1098,6 +1067,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,16 +1261,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
 ]
 
 [[package]]
@@ -1930,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2004,6 +1979,15 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sanitize-filename"
@@ -2488,11 +2472,11 @@ dependencies = [
  "fuzzy-matcher",
  "git-version",
  "globset",
+ "ignore",
  "image",
  "indicatif",
  "is_executable",
  "jojodiff",
- "jwalk",
  "log",
  "num-format",
  "pinmame-nvram",
@@ -2509,6 +2493,16 @@ dependencies = [
  "vpin",
  "wild",
  "zip",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2736,6 +2730,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ serde = { version = "1.0.228", features = ["derive"] }
 log = "0.4.32"
 env_logger = "0.11.10"
 figment = { version = "0.10", features = ["toml", "env"] }
-jwalk = "0.8.1"
 rayon = "1.12.0"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 globset = "0.4.18"
+ignore = "0.4.33"
 
 # num-format's `with-system-locale` feature pulls a winapi path
 # (`winapi::um::errhandlingapi`) without declaring the required winapi

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use jwalk::WalkDir;
+use ignore::{WalkBuilder, WalkState};
 use log::info;
 use rayon::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -348,41 +348,43 @@ pub fn find_vpx_files(
     tables_path: &Path,
 ) -> io::Result<Vec<PathWithMetadata>> {
     let vpx_paths: Vec<PathBuf> = if recursive {
-        // jwalk parallelises readdir calls across directories using rayon, so
-        // all subdirectory reads (e.g. one per manufacturer folder) happen
-        // concurrently rather than serially.
-        let mut walk = WalkDir::new(tables_path).skip_hidden(false);
-        if let Some(depth) = max_depth {
-            walk = walk.max_depth(depth);
-        }
-        walk.process_read_dir(|_, _, _, entries| {
-            // Drop .git and __MACOSX subdirectory entries before they are
-            // enqueued for parallel reads, avoiding wasted network RPCs.
-            entries.retain(|entry| match entry {
-                Ok(e) if e.file_type().is_dir() => {
-                    !matches!(e.file_name().to_str(), Some(".git" | "__MACOSX"))
+        // The parallel walker reads subdirectories (e.g. one per manufacturer
+        // folder) concurrently rather than serially, which matters when each
+        // readdir is a network RPC.
+        let mut builder = WalkBuilder::new(tables_path);
+        // Plain filesystem walk: no gitignore handling, include hidden files.
+        builder.standard_filters(false);
+        builder.max_depth(max_depth);
+        builder.filter_entry(|entry| {
+            // Prune .git and __MACOSX subtrees before they are enqueued for
+            // parallel reads, avoiding wasted network RPCs.
+            !(entry.file_type().is_some_and(|t| t.is_dir())
+                && matches!(entry.file_name().to_str(), Some(".git" | "__MACOSX")))
+        });
+        let (tx, rx) = std::sync::mpsc::channel::<io::Result<PathBuf>>();
+        builder.build_parallel().run(|| {
+            let tx = tx.clone();
+            Box::new(move |entry| {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(e) => {
+                        let _ = tx.send(Err(io::Error::other(e)));
+                        return WalkState::Quit;
+                    }
+                };
+                if entry.file_type().is_some_and(|t| t.is_file())
+                    && matches!(
+                        entry.path().extension().and_then(OsStr::to_str),
+                        Some("vpx")
+                    )
+                {
+                    let _ = tx.send(Ok(entry.into_path()));
                 }
-                _ => true,
-            });
-        })
-        .into_iter()
-        .filter_map(|entry| {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(e) => return Some(Err(io::Error::from(e))),
-            };
-            if !entry.file_type().is_file() {
-                return None;
-            }
-            if !matches!(
-                entry.path().extension().and_then(OsStr::to_str),
-                Some("vpx")
-            ) {
-                return None;
-            }
-            Some(Ok(entry.path()))
-        })
-        .collect::<io::Result<Vec<_>>>()?
+                WalkState::Continue
+            })
+        });
+        drop(tx);
+        rx.into_iter().collect::<io::Result<Vec<_>>>()?
     } else {
         let mut paths = Vec::new();
         for entry in fs::read_dir(tables_path)? {
@@ -1683,6 +1685,31 @@ x = LoadValue(tablename, "HighScore1")
 
         // Depth 0 yields only the root dir entry, which is not a .vpx file.
         assert!(find_vpx_files(true, Some(0), &tables_dir)?.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_vpx_files_includes_hidden_and_gitignored() -> io::Result<()> {
+        // find_vpx_files must do a plain filesystem walk: hidden files and
+        // directories are included, and a stray .gitignore inside a tables
+        // folder must not hide any tables.
+        let tables_dir = testdir!().join("tables");
+        fs::create_dir(&tables_dir)?;
+        let hidden_dir = tables_dir.join(".hidden");
+        fs::create_dir(&hidden_dir)?;
+
+        vpx::new_minimal_vpx(tables_dir.join("visible.vpx"))?;
+        vpx::new_minimal_vpx(tables_dir.join(".hidden.vpx"))?;
+        vpx::new_minimal_vpx(hidden_dir.join("nested.vpx"))?;
+        fs::write(tables_dir.join(".gitignore"), "*.vpx\n")?;
+
+        let mut found: Vec<String> = find_vpx_files(true, None, &tables_dir)?
+            .iter()
+            .map(|f| f.path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        found.sort();
+        assert_eq!(found, vec![".hidden.vpx", "nested.vpx", "visible.vpx"]);
 
         Ok(())
     }


### PR DESCRIPTION
jwalk 0.9.0 is a farewell release: it declares the crate unmaintained and points users to `dua-core`, a library freshly extracted from dua-cli with no docs and no track record on its own (see #852). Instead of upgrading onto a dead crate or adopting its suggested replacement, this switches the one usage in `find_vpx_files` to the `ignore` crate's parallel `WalkBuilder`, from the actively maintained ripgrep workspace we already depend on via `globset`.

Behavior is preserved:
- Parallel directory reads via `build_parallel()`, results collected through a channel
- `standard_filters(false)` disables gitignore handling and includes hidden files, matching jwalk's `skip_hidden(false)`
- `.git` and `__MACOSX` subtrees are pruned in `filter_entry` before their contents are enqueued, keeping the network-RPC saving
- Same walkdir-style `max_depth` semantics; the existing max-depth test passes unchanged
- Walk errors quit the walk and propagate as the first `io::Error`

A new test locks in the plain-walk contract: hidden files/dirs are still found and a stray `.gitignore` in a tables folder has no effect (the ignore crate's defaults would silently change both).

Dependency changes: jwalk and its three crossbeam crates out; ignore, walkdir, same-file, winapi-util in.

Once this merges, dependabot should close #852 automatically since jwalk is no longer in the manifest.