### PR TITLE
fix: read vbs sidecar scripts with latin1 fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,9 +2501,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9650074969d287d3957a985c98979d17bcf961afdaa0de08e0b029a2f64fea4"
+checksum = "a85870489ef07d46f9f8fc3825cd23d1ac7e563610d8519dd86992a325831713"
 dependencies = [
  "byteorder",
  "bytes",
@@ -2512,7 +2512,6 @@ dependencies = [
  "flate2",
  "hex",
  "image",
- "itoa",
  "log",
  "md2",
  "nom 8.0.0",
@@ -2700,12 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "wavefront-obj-io"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac7f033c82919052c8caa9af2e36708768dc32f692e96c9d5dfd317c58a643a"
-dependencies = [
- "itoa",
-]
+checksum = "c8303f48c4cd4d0e4cc8b376b83dee11ce93c95d7d28f829fd213a76fcb3b538"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.27.0" }
+vpin = { version = "0.28.1" }
 directb2s = "0.1.1"
 
 edit = "0.1.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3108,7 +3108,7 @@ pub fn script_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io:
 
                 let modified_vbs_path =
                     RemoveOnDrop::new(vpx_file_path.with_extension("vbs.modified.tmp"));
-                let sidecar_content = crate::patcher::read_vbs_file(&vbs_path)?;
+                let sidecar_content = vpin::vpx::read_script_file(&vbs_path)?;
                 let normalized_modified = unify_line_endings(&sidecar_content.string);
                 std::fs::write(modified_vbs_path.path(), normalized_modified)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3108,8 +3108,8 @@ pub fn script_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io:
 
                 let modified_vbs_path =
                     RemoveOnDrop::new(vpx_file_path.with_extension("vbs.modified.tmp"));
-                let sidecar_content = std::fs::read_to_string(&vbs_path)?;
-                let normalized_modified = unify_line_endings(&sidecar_content);
+                let sidecar_content = crate::patcher::read_vbs_file(&vbs_path)?;
+                let normalized_modified = unify_line_endings(&sidecar_content.string);
                 std::fs::write(modified_vbs_path.path(), normalized_modified)?;
 
                 let diff_color = if colored::control::SHOULD_COLORIZE.should_colorize() {

--- a/src/patcher.rs
+++ b/src/patcher.rs
@@ -3,10 +3,9 @@
 use regex::Regex;
 use std::collections::HashSet;
 use std::fmt::Display;
-use std::fs::File;
 use std::io;
-use std::io::{Read, Write};
 use std::path::Path;
+use vpin::vpx::model::StringWithEncoding;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum LineEndingsResult {
@@ -28,16 +27,37 @@ impl Display for PatchType {
     }
 }
 
+// TODO replace read_vbs_file/write_vbs_file with the identical
+//   vpin::vpx::read_script_file/write_script_file once a vpin release
+//   including them lands.
+
+/// Reads a vbs file the way Visual Pinball does: utf8 if valid, latin1
+/// otherwise. VPinballX -ExtractVBS writes the raw script bytes, so legacy
+/// tables can produce latin1 sidecar scripts.
+pub fn read_vbs_file(vbs_path: &Path) -> io::Result<StringWithEncoding> {
+    let bytes = std::fs::read(vbs_path)?;
+    Ok(bytes.into())
+}
+
+/// Writes a vbs file back in the encoding it was read with, so a latin1
+/// sidecar script stays latin1.
+pub fn write_vbs_file(vbs_path: &Path, script: &StringWithEncoding) -> io::Result<()> {
+    let bytes: Vec<u8> = script.clone().into();
+    std::fs::write(vbs_path, bytes)
+}
+
 pub fn patch_vbs_file(vbs_path: &Path) -> io::Result<HashSet<PatchType>> {
-    // TODO we probably need to ensure proper encoding here in stead of going for utf8
-    let mut file = File::open(vbs_path)?;
-    let mut text = String::new();
-    file.read_to_string(&mut text)?;
+    let script = read_vbs_file(vbs_path)?;
 
-    let (patched_text, applied) = patch_script(text);
+    let (patched_text, applied) = patch_script(script.string);
 
-    let mut file = File::create(vbs_path)?;
-    file.write_all(patched_text.as_bytes())?;
+    write_vbs_file(
+        vbs_path,
+        &StringWithEncoding {
+            encoding: script.encoding,
+            string: patched_text,
+        },
+    )?;
     Ok(applied)
 }
 
@@ -48,17 +68,21 @@ pub fn patch_vbs_file(vbs_path: &Path) -> io::Result<HashSet<PatchType>> {
  * One example is [Aztec (Williams 1976) 1.3 by jipeji16](https://www.vpforums.org/index.php?app=downloads&showfile=15768)
  */
 pub fn unify_line_endings_vbs_file(vbs_path: &Path) -> io::Result<LineEndingsResult> {
-    // TODO we probably need to ensure proper encoding here in stead of going for utf8
-    let mut file = File::open(vbs_path)?;
-    let mut text = String::new();
-    file.read_to_string(&mut text)?;
+    let script = read_vbs_file(vbs_path)?;
+    let text = script.string;
 
     let patched_text = unify_line_endings(&text);
+    let changed = text != patched_text;
 
-    let mut file = File::create(vbs_path)?;
-    file.write_all(patched_text.as_bytes())?;
+    write_vbs_file(
+        vbs_path,
+        &StringWithEncoding {
+            encoding: script.encoding,
+            string: patched_text,
+        },
+    )?;
 
-    if text != patched_text {
+    if changed {
         Ok(LineEndingsResult::Unified)
     } else {
         Ok(LineEndingsResult::NoChanges)
@@ -187,6 +211,37 @@ fn introduce_class(script: String, marker: &str, fallback_marker: &str, class_de
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_unify_line_endings_vbs_file_latin1_keeps_encoding() -> io::Result<()> {
+        let dir = testdir::testdir!();
+        let vbs_path = dir.join("table.vbs");
+        // "cafe" with a latin1 e-acute (0xE9), not valid utf8, mixed endings
+        let latin1_script = vec![b'c', b'a', b'f', 0xE9, b'\r', b'x', b'\n'];
+        std::fs::write(&vbs_path, &latin1_script)?;
+
+        let result = unify_line_endings_vbs_file(&vbs_path)?;
+
+        assert_eq!(result, LineEndingsResult::Unified);
+        // line endings unified to \r\n, e-acute still a single latin1 byte
+        let expected = vec![b'c', b'a', b'f', 0xE9, b'\r', b'\n', b'x', b'\r', b'\n'];
+        assert_eq!(std::fs::read(&vbs_path)?, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_patch_vbs_file_latin1_keeps_encoding() -> io::Result<()> {
+        let dir = testdir::testdir!();
+        let vbs_path = dir.join("table.vbs");
+        let latin1_script = vec![b'r', b'e', b'm', b' ', 0xE9, b'\r', b'\n'];
+        std::fs::write(&vbs_path, &latin1_script)?;
+
+        let applied = patch_vbs_file(&vbs_path)?;
+
+        assert!(applied.is_empty());
+        assert_eq!(std::fs::read(&vbs_path)?, latin1_script);
+        Ok(())
+    }
 
     #[test]
     fn test_unify_line_endings() {

--- a/src/patcher.rs
+++ b/src/patcher.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use std::io;
 use std::path::Path;
 use vpin::vpx::model::StringWithEncoding;
+use vpin::vpx::{read_script_file, write_script_file};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum LineEndingsResult {
@@ -27,31 +28,12 @@ impl Display for PatchType {
     }
 }
 
-// TODO replace read_vbs_file/write_vbs_file with the identical
-//   vpin::vpx::read_script_file/write_script_file once a vpin release
-//   including them lands.
-
-/// Reads a vbs file the way Visual Pinball does: utf8 if valid, latin1
-/// otherwise. VPinballX -ExtractVBS writes the raw script bytes, so legacy
-/// tables can produce latin1 sidecar scripts.
-pub fn read_vbs_file(vbs_path: &Path) -> io::Result<StringWithEncoding> {
-    let bytes = std::fs::read(vbs_path)?;
-    Ok(bytes.into())
-}
-
-/// Writes a vbs file back in the encoding it was read with, so a latin1
-/// sidecar script stays latin1.
-pub fn write_vbs_file(vbs_path: &Path, script: &StringWithEncoding) -> io::Result<()> {
-    let bytes: Vec<u8> = script.clone().into();
-    std::fs::write(vbs_path, bytes)
-}
-
 pub fn patch_vbs_file(vbs_path: &Path) -> io::Result<HashSet<PatchType>> {
-    let script = read_vbs_file(vbs_path)?;
+    let script = read_script_file(vbs_path)?;
 
     let (patched_text, applied) = patch_script(script.string);
 
-    write_vbs_file(
+    write_script_file(
         vbs_path,
         &StringWithEncoding {
             encoding: script.encoding,
@@ -68,13 +50,13 @@ pub fn patch_vbs_file(vbs_path: &Path) -> io::Result<HashSet<PatchType>> {
  * One example is [Aztec (Williams 1976) 1.3 by jipeji16](https://www.vpforums.org/index.php?app=downloads&showfile=15768)
  */
 pub fn unify_line_endings_vbs_file(vbs_path: &Path) -> io::Result<LineEndingsResult> {
-    let script = read_vbs_file(vbs_path)?;
+    let script = read_script_file(vbs_path)?;
     let text = script.string;
 
     let patched_text = unify_line_endings(&text);
     let changed = text != patched_text;
 
-    write_vbs_file(
+    write_script_file(
         vbs_path,
         &StringWithEncoding {
             encoding: script.encoding,

--- a/tests/script_diff_line_endings.rs
+++ b/tests/script_diff_line_endings.rs
@@ -103,3 +103,41 @@ fn script_diff_reports_real_changes_despite_mixed_endings() {
         "expected diff to contain the real change, got:\n{stdout}"
     );
 }
+
+/// A latin1 sidecar (as produced by VPinballX -ExtractVBS on legacy tables)
+/// must not make `script diff` fail with a utf8 error; the real change must
+/// still be reported.
+#[test]
+fn script_diff_handles_latin1_sidecar() {
+    let dir = testdir!();
+
+    let out = vpxtool(&dir, &["new", "table.vpx"]);
+    assert!(out.status.success(), "vpxtool new failed: {:?}", out);
+
+    let out = vpxtool(&dir, &["script", "extract", "table.vpx"]);
+    assert!(
+        out.status.success(),
+        "vpxtool script extract failed: {:?}",
+        out
+    );
+
+    // Append a comment containing a latin1 e-acute (0xE9), making the file
+    // invalid utf8.
+    let vbs_path = dir.join("table.vbs");
+    let mut bytes = std::fs::read(&vbs_path).expect("read vbs");
+    bytes.extend_from_slice(b"' caf\xE9 comment\r\n");
+    std::fs::write(&vbs_path, &bytes).expect("write vbs");
+
+    let out = vpxtool(&dir, &["script", "diff", "table.vpx"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "script diff exited with failure: {:?}\nstderr: {stderr}",
+        out.status,
+    );
+    assert!(
+        stdout.contains("comment"),
+        "expected diff to contain the added latin1 line, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Problem

VPinballX `-ExtractVBS` writes the raw script bytes, so legacy tables produce latin1 sidecar scripts. `script diff`, `patch` and `unify` read them with `read_to_string` and failed on non-utf8 content.

## Changes

- read sidecar scripts the way Visual Pinball does (utf8 if valid, latin1 otherwise) in script diff, patch and unify, via the new `read_script_file`/`write_script_file` from vpin 0.28.1 (francisdb/vpin#353)
- patch and unify write the file back in its original encoding
- bump vpin 0.27.0 -> 0.28.1, which also makes `extractvbs`/`importvbs` round trips byte-identical

Removes both `TODO ... proper encoding` comments in `patcher.rs`. Covered by latin1 tests for script diff, patch and unify.