### PR TITLE
build(deps): bump pinmame-nvram from 0.4.14 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,13 +1661,12 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pinmame-nvram"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60431bc3e86b1d326d2cbbb9110e1d880cbe75e66ab733af06710009c4d7802e"
+checksum = "fa3470fc82d153f5edb1b25226a7570257bf15b27c4bee115d1a7763871cf44f"
 dependencies = [
  "brotli",
  "include_dir",
- "lazy_static",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ vpin = { version = "0.27.0" }
 directb2s = "0.1.1"
 
 edit = "0.1.5"
-pinmame-nvram = "0.4.12"
+pinmame-nvram = "0.4.16"
 image = { version = "0.25.10", default-features = false, features = [
     "bmp",
     "exr",


### PR DESCRIPTION
Manual manifest bump (Cargo.toml still said 0.4.12, lockfile was at 0.4.14) so the update shows up for release-plz. Picks up the updated pinball-memory-maps data.