### PR TITLE
fix(indexer): follow pinmame rom alias when locating roms

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2249,6 +2249,49 @@ LoadVPM "01210000","sys80.vbs",3.10
     }
 
     #[test]
+    fn test_find_local_rom_path_follows_alias() {
+        // VPinBall/VPinMAME resolves the script game name through
+        // <pinmame>/alias.txt before looking for the rom zip. Real case:
+        // Mass Effect's script uses "afm_113b_me" but the rom on disk is
+        // "afm_113b.zip", mapped by an "afm_113b_me,afm_113b" alias line.
+        let test_table_dir = testdir!();
+        let vpx_path = test_table_dir.join("test.vpx");
+        let pinmame_dir = test_table_dir.join("pinmame");
+        let roms_dir = pinmame_dir.join("roms");
+        fs::create_dir_all(&roms_dir).unwrap();
+        let real_rom_path = roms_dir.join("afm_113b.zip");
+        File::create(&real_rom_path).unwrap();
+        // CRLF endings and a `#` comment line, matching the on-disk format.
+        fs::write(
+            pinmame_dir.join("alias.txt"),
+            "# mods\r\nafm_113b_me,afm_113b\r\n",
+        )
+        .unwrap();
+
+        let found = find_local_rom_path(&vpx_path, &Some("afm_113b_me".to_string()), None).unwrap();
+        assert_eq!(found, Some(real_rom_path.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn test_find_local_rom_path_alias_wins_over_direct() {
+        // VPinMAME applies the alias unconditionally (GetGameNumFromString
+        // always calls CheckGameAlias), so an alias entry wins even when a
+        // <game_name>.zip is also present.
+        let test_table_dir = testdir!();
+        let vpx_path = test_table_dir.join("test.vpx");
+        let pinmame_dir = test_table_dir.join("pinmame");
+        let roms_dir = pinmame_dir.join("roms");
+        fs::create_dir_all(&roms_dir).unwrap();
+        File::create(roms_dir.join("gamename.zip")).unwrap();
+        let aliased_rom_path = roms_dir.join("other.zip");
+        File::create(&aliased_rom_path).unwrap();
+        fs::write(pinmame_dir.join("alias.txt"), "gamename,other\r\n").unwrap();
+
+        let found = find_local_rom_path(&vpx_path, &Some("gamename".to_string()), None).unwrap();
+        assert_eq!(found, Some(aliased_rom_path.canonicalize().unwrap()));
+    }
+
+    #[test]
     fn test_find_altsound_path_per_table_priority() {
         let dir = testdir!();
         // Both per-table layouts present. Priority 1 (altsound/) wins.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -850,8 +850,6 @@ fn find_local_rom_path(
     configured_roms_path: Option<&Path>,
 ) -> io::Result<Option<PathBuf>> {
     if let Some(game_name) = game_name {
-        let rom_file_name = format!("{}.zip", game_name.to_lowercase());
-
         let pinmame_roms_path = if let Some(configured_roms_path) = configured_roms_path {
             let configured_roms_path = if configured_roms_path.is_relative() {
                 vpx_file_path.parent().unwrap().join(configured_roms_path)
@@ -867,7 +865,18 @@ fn find_local_rom_path(
             vpx_file_path.parent().unwrap().join("pinmame").join("roms")
         };
 
-        let rom_path = pinmame_roms_path.join(rom_file_name);
+        // VPinMAME resolves the script game name through the alias file
+        // (<pinmame>/alias.txt, sibling of roms/) before looking anything up:
+        // GetGameNumFromString calls CheckGameAlias unconditionally. So an
+        // alias entry (e.g. "afm_113b_me,afm_113b") wins even when
+        // <game_name>.zip is also present. Fall back to the literal name when
+        // no alias matches.
+        let rom_name = pinmame_roms_path
+            .parent()
+            .and_then(|alias_dir| resolve_rom_alias(alias_dir, game_name))
+            .unwrap_or_else(|| game_name.to_lowercase());
+
+        let rom_path = pinmame_roms_path.join(format!("{rom_name}.zip"));
         return if rom_path.exists() {
             Ok(Some(rom_path.canonicalize()?))
         } else {
@@ -875,6 +884,36 @@ fn find_local_rom_path(
         };
     };
     Ok(None)
+}
+
+/// Resolve a script game name to the real rom name via VPinMAME's alias file
+/// at `<pinmame_dir>/alias.txt`, as read by pinmame's `CheckGameAlias`.
+///
+/// Each entry is `<alias>,<real>`; the tokens split on a comma or space, so
+/// `a,b`, `a, b`, and `a b` are equivalent. A line starting with `#` is a
+/// comment. The real name ends at the first space, comma, `#`, `;`, or `'`,
+/// which drops any trailing inline comment. The match is case-insensitive.
+/// Returns the mapped real rom name, or `None` when the file is absent or has
+/// no matching alias.
+fn resolve_rom_alias(pinmame_dir: &Path, game_name: &str) -> Option<String> {
+    let contents = fs::read_to_string(pinmame_dir.join("alias.txt")).ok()?;
+    contents.lines().find_map(|line| {
+        if line.starts_with('#') {
+            return None;
+        }
+        // pinmame splits the alias on its `", "` delimiter set (comma or
+        // space); `.lines()` already stripped the `\n`/`\r\n` line ending.
+        let mut tokens = line.split([',', ' ']).filter(|t| !t.is_empty());
+        let alias = tokens.next()?;
+        if !alias.eq_ignore_ascii_case(game_name) {
+            return None;
+        }
+        let real = tokens.next()?;
+        // pinmame terminates the real name at any of these; a token split on
+        // comma/space can still carry a trailing `#`/`;`/`'` inline comment.
+        let real = real.split(['#', ';', '\'']).next()?;
+        (!real.is_empty()).then(|| real.to_string())
+    })
 }
 
 fn find_b2s_path(vpx_file_path: &Path) -> Option<PathBuf> {
@@ -2289,6 +2328,42 @@ LoadVPM "01210000","sys80.vbs",3.10
 
         let found = find_local_rom_path(&vpx_path, &Some("gamename".to_string()), None).unwrap();
         assert_eq!(found, Some(aliased_rom_path.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn test_resolve_rom_alias_tokenizes_like_pinmame() {
+        // pinmame's CheckGameAlias splits on comma or space, treats a leading
+        // `#` as a comment, and terminates the real name at ` ,#;'`. Match is
+        // case-insensitive. Pin each of those against one alias file.
+        let dir = testdir!();
+        fs::write(
+            dir.join("alias.txt"),
+            "# comment line\r\n\
+             comma,realcomma\r\n\
+             spaced realspaced\r\n\
+             padded , realpadded \r\n\
+             trailing,realtrailing # inline note\r\n",
+        )
+        .unwrap();
+
+        assert_eq!(resolve_rom_alias(&dir, "comma"), Some("realcomma".into()));
+        assert_eq!(resolve_rom_alias(&dir, "spaced"), Some("realspaced".into()));
+        assert_eq!(resolve_rom_alias(&dir, "padded"), Some("realpadded".into()));
+        assert_eq!(
+            resolve_rom_alias(&dir, "trailing"),
+            Some("realtrailing".into())
+        );
+        // Case-insensitive alias match.
+        assert_eq!(resolve_rom_alias(&dir, "COMMA"), Some("realcomma".into()));
+        // Unknown alias and the commented line both miss.
+        assert_eq!(resolve_rom_alias(&dir, "comment"), None);
+        assert_eq!(resolve_rom_alias(&dir, "missing"), None);
+    }
+
+    #[test]
+    fn test_resolve_rom_alias_absent_file() {
+        let dir = testdir!();
+        assert_eq!(resolve_rom_alias(&dir, "anything"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Why

The frontend showed a missing-rom warning for tables whose script game name is aliased to a differently named rom set, even though the rom was present under its real name. vpxtool built `<game_name>.zip` literally and never consulted VPinMAME's alias file, so an aliased name like `afm_113b_me` never resolved to its real rom `afm_113b.zip`.

## Scope

`src/indexer.rs`. Adds `resolve_rom_alias` and changes `find_local_rom_path` to resolve the script game name through `<pinmame>/alias.txt` (sibling of `roms/`) before the rom lookup, then search for `<resolved_name>.zip`. Falls back to the literal game name when no alias matches.

The parser mirrors pinmame's `CheckGameAlias` (in `libpinmame`, the code the standalone build runs): split the alias on a comma or space, skip lines whose first character is `#`, end the real name at `#`, `;`, or `'`, and match case-insensitively. The Windows-only `VPMAlias.txt` path is a separate mechanism and is out of scope.

## Tradeoffs

pinmame calls `CheckGameAlias` unconditionally in `GetGameNumFromString`, so an alias entry wins even when a direct `<game_name>.zip` also exists. This resolves the alias first rather than treating it as a fallback, which matches pinmame and means one `alias.txt` read attempt per table.

## Blast Radius

Touches only local rom resolution during indexing. The global `~/.pinmame/roms` lookup is unchanged. The added per-table read is a single `alias.txt` open attempt. A cold full force-reindex of 688 tables on a NAS measured 62.6s with the alias read versus 63.3s without it, within run-to-run noise, because indexing already opens each `.vpx` and reads its parent directory, so the metadata the alias read needs is already warm.

Existing indexes cache the previous "missing" state. After upgrading, run a force reload once (or `index --force`) to pick up the fix, the same upgrade step already documented for newly detected fields like altsound and altcolor. A normal reload does not re-index these tables because their `.vpx` files are unchanged and their cached `rom_path` was already null.

## Verification

- `cargo test`: 151 lib tests plus the integration suites pass. New tests `test_find_local_rom_path_follows_alias`, `test_find_local_rom_path_alias_wins_over_direct`, `test_resolve_rom_alias_tokenizes_like_pinmame`, and `test_resolve_rom_alias_absent_file`. The failing repro lands in the first commit (both alias tests fail red against the unfixed code) and the fix greens them in the second.
- `cargo fmt --check` and `cargo clippy --lib` clean.
- End to end against a real 10.8.1 collection: after the fix, four aliased tables resolved their rom (`afm_113b_me` to `afm_113b`, `nfl_sea` to `nfl`, `grease` to `elvis`, `simpprtyh` to `simpprty`), and the frontend dropped the warning after a force reload.