### PR TITLE
feat: add a vpx level diff command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom 7.1.3",
+ "nom",
  "num-rational",
  "v_frame",
 ]
@@ -349,12 +349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,7 +411,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1378,6 +1372,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,15 +1477,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2517,6 +2534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vbscript"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a55e59a0ecd1e1963af43a06e70fbc6fd94d040bda7cc7f5b5befc83abc8f4"
+dependencies = [
+ "logos",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,11 +2550,10 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.28.2"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb54aec4da9750faeb34e4a373654f4e8fa11a800cb3e81bca130e793a70df9"
+checksum = "d060dadf04acf32892b99d2b4913be9aa1a40eb9077026e8437d8de520ef7ac9"
 dependencies = [
- "byteorder",
  "bytes",
  "cfb",
  "encoding_rs",
@@ -2537,14 +2562,13 @@ dependencies = [
  "image",
  "log",
  "md2",
- "nom 8.0.0",
  "rayon",
- "regex",
  "sanitize-filename",
  "serde",
  "serde_json",
  "tracing",
  "unicode-normalization",
+ "vbscript",
  "wavefront-obj-io",
  "weezl 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.28.1" }
+vpin = { version = "0.31.1", features = ["script-audit"] }
 directb2s = "0.1.1"
 
 edit = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Usage: vpxtool [COMMAND]
 
 Commands:
   info            Vpx table info related commands
-  diff            Prints out a diff between the vbs in the vpx and the sidecar vbs
+  diff            Compares two vpx files and lists what differs
   frontend        Text based frontend for launching vpx files
   simplefrontend  Simple text based frontend for launching vpx files
   index           Indexes a directory of vpx files

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2372,6 +2372,7 @@ fn handle_sounds_list(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             let output = match sound.output_target {
                 vpin::vpx::sound::OutputTarget::Table => "table",
                 vpin::vpx::sound::OutputTarget::Backglass => "backglass",
+                vpin::vpx::sound::OutputTarget::Other(_) => "unknown",
             };
             // For WAV (PCM) we can derive the playback duration from the raw
             // sample bytes; for non-WAV containers the data is compressed and
@@ -3013,7 +3014,7 @@ fn info_import(_vpx_file_path: &Path) -> io::Result<ExitCode> {
 }
 
 pub fn ls(vpx_file_path: &Path) -> io::Result<()> {
-    expanded::extract_directory_list(vpx_file_path)
+    expanded::extract_directory_list(vpx_file_path)?
         .iter()
         .try_for_each(|file_path| crate::println!("{}", file_path))
 }
@@ -3224,7 +3225,7 @@ fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
     match action {
         LockAction::Status => {
             let mut vpx = vpx::open(path)?;
-            let state = if vpx.is_locked()? {
+            let state = if vpx.is_table_locked()? {
                 "locked"
             } else {
                 "unlocked"
@@ -3233,7 +3234,7 @@ fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
         }
         LockAction::Lock => {
             let mut vpx = vpx::open_rw(path)?;
-            if vpx.lock()? {
+            if vpx.lock_table()? {
                 crate::println!("Locked {}", path.display())?;
             } else {
                 crate::println!("Already locked: {}", path.display())?;
@@ -3241,7 +3242,7 @@ fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
         }
         LockAction::Unlock => {
             let mut vpx = vpx::open_rw(path)?;
-            if vpx.unlock()? {
+            if vpx.unlock_table()? {
                 crate::println!("Unlocked {}", path.display())?;
             } else {
                 crate::println!("Already unlocked: {}", path.display())?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use crate::{
 use base64::Engine;
 use clap::builder::Str;
 use clap::{Arg, ArgAction, ArgMatches, Command, arg};
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use console::Emoji;
 use directb2s::read;
 use git_version::git_version;
@@ -26,6 +26,7 @@ use std::process::{ExitCode, exit};
 use std::time::{Duration, SystemTime};
 use vpin::filesystem::RealFileSystem;
 use vpin::vpx;
+use vpin::vpx::diff::Difference;
 use vpin::vpx::expanded::ExpandOptions;
 use vpin::vpx::export::gltf_export::{GltfExportOptions, GltfFormat, export_gltf};
 use vpin::vpx::export::obj_export::{ExportUnits, ObjExportOptions, export_obj};
@@ -248,13 +249,34 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
             _ => unreachable!(),
         },
         Some((CMD_DIFF, sub_matches)) => {
-            // TODO this should diff more than only the script
-            let path = sub_matches.get_one::<String>("VPXPATH").map(|s| s.as_str());
-            let path = path.unwrap_or("");
-            let expanded_path = path_exists(path)?;
+            let original = sub_matches
+                .get_one::<String>("ORIGINAL")
+                .map(|s| s.as_str())
+                .unwrap_or("");
+            let original_path = path_exists(original)?;
+            if let Some(modified) = sub_matches.get_one::<String>("MODIFIED") {
+                let modified_path = path_exists(modified)?;
+                let differences = vpx_diff(&original_path, &modified_path)?;
+                for difference in &differences {
+                    crate::println!("{}", colorize_difference(difference))?;
+                }
+                return if differences.is_empty() {
+                    Ok(ExitCode::SUCCESS)
+                } else {
+                    Ok(ExitCode::from(1))
+                };
+            }
+            // Legacy single path form, kept for scripts that predate `script diff`
+            crate::eprintln!(
+                "{}",
+                format!(
+                    "{WARN} `diff` with a single path is deprecated, use `script diff` instead"
+                )
+                .yellow()
+            )?;
             let loaded_config = config::load_config()?;
             let config = loaded_config.as_ref().map(|c| &c.1);
-            match script_diff(&expanded_path, config) {
+            match script_diff(&original_path, config) {
                 Ok(output) => {
                     crate::println!("{}", output)?;
                     Ok(ExitCode::SUCCESS)
@@ -1080,8 +1102,18 @@ fn build_command() -> Command {
         )
         .subcommand(
             Command::new(CMD_DIFF)
-                .about("Prints out a diff between the vbs in the vpx and the sidecar vbs")
-                .arg(arg!(<VPXPATH> "The path to the vpx file").required(true))
+                .about("Compares two vpx files and lists what differs")
+                .long_about(
+                    "Compares two vpx files at the file level: streams that were added or \
+                    removed, and for changed streams the record that differs, labeled with \
+                    the game item, image or script it belongs to. Harmless differences such \
+                    as the integrity signature and the compression encoding are ignored.\n\n\
+                    Exits with status 1 when the files differ.\n\n\
+                    With a single path this falls back to the deprecated behaviour of \
+                    diffing the script against the sidecar vbs, use `script diff` for that.",
+                )
+                .arg(arg!(<ORIGINAL> "The path to the original vpx file").required(true))
+                .arg(arg!([MODIFIED] "The path to the modified vpx file")),
         )
         .subcommand(
             Command::new(CMD_FRONTEND)
@@ -3088,6 +3120,22 @@ pub fn info_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io::R
     } else {
         let msg = format!("No sidecar info file found: {}", info_file_path.display());
         Err(io::Error::new(io::ErrorKind::NotFound, msg))
+    }
+}
+
+/// Compares two vpx files at the file level, see [`vpin::vpx::diff`]
+pub fn vpx_diff(original: &Path, modified: &Path) -> io::Result<Vec<Difference>> {
+    let original_bytes = std::fs::read(original)?;
+    let modified_bytes = std::fs::read(modified)?;
+    vpin::vpx::diff::diff(&original_bytes, &modified_bytes)
+}
+
+fn colorize_difference(difference: &Difference) -> ColoredString {
+    let text = difference.to_string();
+    match difference {
+        Difference::StreamAdded { .. } | Difference::RecordAdded { .. } => text.green(),
+        Difference::StreamRemoved { .. } | Difference::RecordRemoved { .. } => text.red(),
+        _ => text.yellow(),
     }
 }
 

--- a/tests/vpx_diff.rs
+++ b/tests/vpx_diff.rs
@@ -1,0 +1,50 @@
+//! `diff` compares two vpx files and exits non-zero when they differ.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use testdir::testdir;
+
+fn vpxtool(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_vpxtool"))
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vpxtool")
+        .wait_with_output()
+        .expect("failed to wait for vpxtool")
+}
+
+#[test]
+fn diff_reports_no_differences_for_identical_files() {
+    let dir = testdir!();
+    let out = vpxtool(&dir, &["new", "table.vpx"]);
+    assert!(out.status.success(), "vpxtool new failed: {:?}", out);
+    std::fs::copy(dir.join("table.vpx"), dir.join("copy.vpx")).expect("copy vpx");
+
+    let out = vpxtool(&dir, &["diff", "table.vpx", "copy.vpx"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "diff failed: {:?}", out);
+    assert!(stdout.trim().is_empty(), "unexpected output: {stdout}");
+}
+
+#[test]
+fn diff_reports_changed_record_and_exits_non_zero() {
+    let dir = testdir!();
+    let out = vpxtool(&dir, &["new", "table.vpx"]);
+    assert!(out.status.success(), "vpxtool new failed: {:?}", out);
+    std::fs::copy(dir.join("table.vpx"), dir.join("locked.vpx")).expect("copy vpx");
+    // locking bumps the TLCK counter in the game data stream
+    let out = vpxtool(&dir, &["lock", "locked.vpx"]);
+    assert!(out.status.success(), "vpxtool lock failed: {:?}", out);
+
+    let out = vpxtool(&dir, &["diff", "table.vpx", "locked.vpx"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(out.status.code(), Some(1), "expected exit 1: {:?}", out);
+    assert!(
+        stdout.contains("/GameStg/GameData") && stdout.contains("TLCK"),
+        "unexpected output: {stdout}"
+    );
+}


### PR DESCRIPTION
Bumps vpin to 0.31.1 and adds a vpx level diff command.

`vpxtool diff original.vpx modified.vpx` lists the streams and records that differ between two tables, labeled with the game item, image or script they belong to. Harmless differences (the integrity signature, compression encoding, uninitialized padding) are ignored by vpin, so an empty diff means the files hold the same table. The command exits with status 1 when the files differ, so it can be used in scripts.

The old single path form ran the sidecar script diff. It still does, but now prints a deprecation hint pointing to `script diff`.

The vpin bump also adapts to the renamed table lock methods, the new unknown sound output target variant and the fallible directory listing, and enables the `script-audit` feature for the follow-up audit PR.
