### PR TITLE
feat: add a table audit command and frontend entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Commands:
   extractvbs      Extracts the vbs from a vpx file next to it
   importvbs       Imports the vbs next to it into a vpx file
   verify          Verify the structure of a vpx file
+  audit           Reports consistency problems in a vpx file
   assemble        Assembles a vpx file
   patch           Applies a VPURemix System patch to a table
   new             Creates a minimal empty new vpx file

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,7 @@ use std::process::{ExitCode, exit};
 use std::time::{Duration, SystemTime};
 use vpin::filesystem::RealFileSystem;
 use vpin::vpx;
+use vpin::vpx::audit::{Finding, Severity};
 use vpin::vpx::expanded::ExpandOptions;
 use vpin::vpx::export::gltf_export::{GltfExportOptions, GltfFormat, export_gltf};
 use vpin::vpx::export::obj_export::{ExportUnits, ObjExportOptions, export_obj};
@@ -52,6 +53,7 @@ const CMD_EXTRACT_VBS: &str = "extractvbs";
 const CMD_IMPORT_VBS: &str = "importvbs";
 const CMD_PATCH: &str = "patch";
 const CMD_VERIFY: &str = "verify";
+const CMD_AUDIT: &str = "audit";
 const CMD_NEW: &str = "new";
 const CMD_LOCK: &str = "lock";
 const CMD_UNLOCK: &str = "unlock";
@@ -615,6 +617,27 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 }
             }
             Ok(ExitCode::SUCCESS)
+        }
+        Some((CMD_AUDIT, sub_matches)) => {
+            let paths: Vec<&str> = sub_matches
+                .get_many::<String>("VPXPATH")
+                .unwrap_or_default()
+                .map(|v| v.as_str())
+                .collect::<Vec<_>>();
+            let mut has_errors = false;
+            for path in paths {
+                let expanded_path = path_exists(path)?;
+                let findings = audit_table(&expanded_path)?;
+                crate::println!("{}", format_audit(&expanded_path, &findings))?;
+                has_errors |= findings
+                    .iter()
+                    .any(|finding| finding.severity() == Severity::Error);
+            }
+            if has_errors {
+                Ok(ExitCode::from(1))
+            } else {
+                Ok(ExitCode::SUCCESS)
+            }
         }
 
         Some((CMD_LOCK, sub_matches)) => run_lock(sub_matches, LockAction::Lock),
@@ -1269,6 +1292,23 @@ fn build_command() -> Command {
         .subcommand(
             Command::new(CMD_VERIFY)
                 .about("Verify the structure of a vpx file")
+                .arg(
+                    arg!(<VPXPATH> "The path(s) to the vpx file(s)")
+                        .required(true)
+                        .num_args(1..),
+                ),
+        )
+        .subcommand(
+            Command::new(CMD_AUDIT)
+                .about("Reports consistency problems in a vpx file")
+                .long_about(
+                    "Reports problems vpinball tolerates at runtime but that usually mean \
+                    something went wrong while producing the table: references to images, \
+                    materials, surfaces, part groups or collection items that do not exist, \
+                    duplicate or over-long names, script issues and a few storage level \
+                    suggestions.\n\n\
+                    Exits with status 1 when a finding of error severity is reported.",
+                )
                 .arg(
                     arg!(<VPXPATH> "The path(s) to the vpx file(s)")
                         .required(true)
@@ -3089,6 +3129,47 @@ pub fn info_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io::R
         let msg = format!("No sidecar info file found: {}", info_file_path.display());
         Err(io::Error::new(io::ErrorKind::NotFound, msg))
     }
+}
+
+/// Runs the vpin consistency audit on a vpx file, see [`vpin::vpx::audit`]
+pub fn audit_table(vpx_file_path: &Path) -> io::Result<Vec<Finding>> {
+    let vpx = vpx::read(vpx_file_path)?;
+    let mut findings = vpin::vpx::audit::audit(&vpx);
+    // most serious first, keeping the audit order within a severity
+    findings.sort_by_key(|finding| std::cmp::Reverse(finding.severity()));
+    Ok(findings)
+}
+
+/// Formats audit findings as a colored report with a summary line
+pub fn format_audit(vpx_file_path: &Path, findings: &[Finding]) -> String {
+    let mut report = format!("{}\n", vpx_file_path.display().to_string().bold());
+    let mut errors = 0;
+    let mut warnings = 0;
+    let mut suggestions = 0;
+    for finding in findings {
+        let marker = match finding.severity() {
+            Severity::Error => {
+                errors += 1;
+                "error".red()
+            }
+            Severity::Warning => {
+                warnings += 1;
+                "warning".yellow()
+            }
+            _ => {
+                suggestions += 1;
+                "suggestion".cyan()
+            }
+        };
+        report.push_str(&format!("  {marker}: {finding}\n"));
+    }
+    let summary = if findings.is_empty() {
+        format!("{OK} no problems found").to_string()
+    } else {
+        format!("{errors} errors, {warnings} warnings, {suggestions} suggestions")
+    };
+    report.push_str(&format!("  {summary}"));
+    report
 }
 
 pub fn script_diff(vpx_file_path: &Path, config: Option<&ResolvedConfig>) -> io::Result<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -626,12 +626,22 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .collect::<Vec<_>>();
             let mut has_errors = false;
             for path in paths {
-                let expanded_path = path_exists(path)?;
-                let findings = audit_table(&expanded_path)?;
-                crate::println!("{}", format_audit(&expanded_path, &findings))?;
-                has_errors |= findings
-                    .iter()
-                    .any(|finding| finding.severity() == Severity::Error);
+                // keep going when one table fails to load, the others are still worth a report
+                let audited = path_exists(path)
+                    .and_then(|expanded_path| Ok((audit_table(&expanded_path)?, expanded_path)));
+                match audited {
+                    Ok((findings, expanded_path)) => {
+                        crate::println!("{}", format_audit(&expanded_path, &findings))?;
+                        has_errors |= findings
+                            .iter()
+                            .any(|finding| finding.severity() == Severity::Error);
+                    }
+                    Err(e) => {
+                        let warning = format!("{NOK} {path}: {e}").red();
+                        crate::eprintln!("{}", warning)?;
+                        has_errors = true;
+                    }
+                }
             }
             if has_errors {
                 Ok(ExitCode::from(1))
@@ -3146,6 +3156,7 @@ pub fn format_audit(vpx_file_path: &Path, findings: &[Finding]) -> String {
     let mut errors = 0;
     let mut warnings = 0;
     let mut suggestions = 0;
+    let mut infos = 0;
     for finding in findings {
         let marker = match finding.severity() {
             Severity::Error => {
@@ -3156,6 +3167,10 @@ pub fn format_audit(vpx_file_path: &Path, findings: &[Finding]) -> String {
                 warnings += 1;
                 "warning".yellow()
             }
+            Severity::Info => {
+                infos += 1;
+                "info".dimmed()
+            }
             _ => {
                 suggestions += 1;
                 "suggestion".cyan()
@@ -3164,9 +3179,9 @@ pub fn format_audit(vpx_file_path: &Path, findings: &[Finding]) -> String {
         report.push_str(&format!("  {marker}: {finding}\n"));
     }
     let summary = if findings.is_empty() {
-        format!("{OK} no problems found").to_string()
+        format!("{OK} no problems found")
     } else {
-        format!("{errors} errors, {warnings} warnings, {suggestions} suggestions")
+        format!("{errors} errors, {warnings} warnings, {suggestions} suggestions, {infos} info")
     };
     report.push_str(&format!("  {summary}"));
     report

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -1,8 +1,8 @@
 use crate::backglass::find_hole;
 use crate::capture::{CaptureOptions, CaptureOutcome, capture_table};
 use crate::cli::{
-    DiffColor, ProgressBarProgress, confirm, info_diff, info_edit, info_gather, open_editor,
-    run_diff, script_diff,
+    DiffColor, ProgressBarProgress, audit_table, confirm, format_audit, info_diff, info_edit,
+    info_gather, open_editor, run_diff, script_diff,
 };
 use crate::colorful_theme_patched::ColorfulThemePatched;
 use crate::config::{LaunchTemplate, ResolvedConfig};
@@ -46,6 +46,7 @@ enum TableOption {
     InfoShow,
     InfoEdit,
     InfoDiff,
+    Audit,
     ExtractVBS,
     EditVBS,
     PatchVBS,
@@ -77,6 +78,7 @@ impl TableOption {
             TableOption::InfoShow,
             TableOption::InfoEdit,
             TableOption::InfoDiff,
+            TableOption::Audit,
             TableOption::ExtractVBS,
             TableOption::EditVBS,
             TableOption::PatchVBS,
@@ -104,6 +106,7 @@ impl TableOption {
             TableOption::InfoShow => "Info > Show".to_string(),
             TableOption::InfoEdit => "Info > Edit".to_string(),
             TableOption::InfoDiff => "Info > Diff".to_string(),
+            TableOption::Audit => "Audit".to_string(),
             TableOption::ExtractVBS => "VBScript > Extract".to_string(),
             TableOption::EditVBS => "VBScript > Edit".to_string(),
             TableOption::PatchVBS => "VBScript > Patch typical standalone issues".to_string(),
@@ -451,6 +454,15 @@ fn table_menu(
                 }
                 Err(err) => {
                     let msg = format!("Unable to diff info: {err}");
+                    prompt_error(&msg);
+                }
+            },
+            Some(TableOption::Audit) => match audit_table(selected_path) {
+                Ok(findings) => {
+                    prompt(&format_audit(selected_path, &findings));
+                }
+                Err(err) => {
+                    let msg = format!("Unable to audit table: {err}");
                     prompt_error(&msg);
                 }
             },

--- a/tests/vpx_audit.rs
+++ b/tests/vpx_audit.rs
@@ -1,0 +1,36 @@
+//! `audit` reports consistency problems and only fails on error findings.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use testdir::testdir;
+
+fn vpxtool(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_vpxtool"))
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vpxtool")
+        .wait_with_output()
+        .expect("failed to wait for vpxtool")
+}
+
+#[test]
+fn audit_reports_findings_for_new_table() {
+    let dir = testdir!();
+    let out = vpxtool(&dir, &["new", "table.vpx"]);
+    assert!(out.status.success(), "vpxtool new failed: {:?}", out);
+
+    let out = vpxtool(&dir, &["audit", "table.vpx"]);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // a fresh table has warnings (no table name) but nothing of error severity
+    assert!(out.status.success(), "audit failed: {:?}", out);
+    assert!(stdout.contains("table.vpx"), "unexpected output: {stdout}");
+    assert!(
+        stdout.contains("table info has no table name"),
+        "unexpected output: {stdout}"
+    );
+    assert!(stdout.contains("0 errors"), "unexpected output: {stdout}");
+}


### PR DESCRIPTION
Adds a table audit command.

`vpxtool audit table.vpx [more.vpx ...]` runs the vpin consistency checks and prints the findings per file, sorted by severity with a summary line. It reports dangling image, material, surface, part group and collection references, duplicate or over-long names, timers faster than a frame, stereo table sounds, script issues such as a missing `Option Explicit` or a missing PinMAME timer, and a few storage suggestions. The command exits with status 1 when a finding of error severity is present.

The frontend gets an "Audit" entry in the table menu that shows the same report.