### PR TITLE
build(deps): bump vpin from 0.28.2 to 0.31.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "log",
- "nom 7.1.3",
+ "nom",
  "num-rational",
  "v_frame",
 ]
@@ -349,12 +349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,7 +411,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1378,6 +1372,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,15 +1477,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2517,6 +2534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vbscript"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a55e59a0ecd1e1963af43a06e70fbc6fd94d040bda7cc7f5b5befc83abc8f4"
+dependencies = [
+ "logos",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,11 +2550,10 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.28.2"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb54aec4da9750faeb34e4a373654f4e8fa11a800cb3e81bca130e793a70df9"
+checksum = "d060dadf04acf32892b99d2b4913be9aa1a40eb9077026e8437d8de520ef7ac9"
 dependencies = [
- "byteorder",
  "bytes",
  "cfb",
  "encoding_rs",
@@ -2537,14 +2562,13 @@ dependencies = [
  "image",
  "log",
  "md2",
- "nom 8.0.0",
  "rayon",
- "regex",
  "sanitize-filename",
  "serde",
  "serde_json",
  "tracing",
  "unicode-normalization",
+ "vbscript",
  "wavefront-obj-io",
  "weezl 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.28.1" }
+vpin = { version = "0.31.1", features = ["script-audit"] }
 directb2s = "0.1.1"
 
 edit = "0.1.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2372,6 +2372,7 @@ fn handle_sounds_list(sub_matches: &ArgMatches) -> io::Result<ExitCode> {
             let output = match sound.output_target {
                 vpin::vpx::sound::OutputTarget::Table => "table",
                 vpin::vpx::sound::OutputTarget::Backglass => "backglass",
+                vpin::vpx::sound::OutputTarget::Other(_) => "unknown",
             };
             // For WAV (PCM) we can derive the playback duration from the raw
             // sample bytes; for non-WAV containers the data is compressed and
@@ -3013,7 +3014,7 @@ fn info_import(_vpx_file_path: &Path) -> io::Result<ExitCode> {
 }
 
 pub fn ls(vpx_file_path: &Path) -> io::Result<()> {
-    expanded::extract_directory_list(vpx_file_path)
+    expanded::extract_directory_list(vpx_file_path)?
         .iter()
         .try_for_each(|file_path| crate::println!("{}", file_path))
 }
@@ -3224,7 +3225,7 @@ fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
     match action {
         LockAction::Status => {
             let mut vpx = vpx::open(path)?;
-            let state = if vpx.is_locked()? {
+            let state = if vpx.is_table_locked()? {
                 "locked"
             } else {
                 "unlocked"
@@ -3233,7 +3234,7 @@ fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
         }
         LockAction::Lock => {
             let mut vpx = vpx::open_rw(path)?;
-            if vpx.lock()? {
+            if vpx.lock_table()? {
                 crate::println!("Locked {}", path.display())?;
             } else {
                 crate::println!("Already locked: {}", path.display())?;
@@ -3241,7 +3242,7 @@ fn apply_lock_action(path: &Path, action: &LockAction) -> io::Result<()> {
         }
         LockAction::Unlock => {
             let mut vpx = vpx::open_rw(path)?;
-            if vpx.unlock()? {
+            if vpx.unlock_table()? {
                 crate::println!("Unlocked {}", path.display())?;
             } else {
                 crate::println!("Already unlocked: {}", path.display())?;


### PR DESCRIPTION
Bumps vpin from 0.28.2 to 0.31.1.

The bump crosses three breaking releases. The table lock methods were renamed, the sound output target gained an unknown variant instead of panicking on unexpected values, and the expanded directory listing now returns a result. The three call sites are adapted. The `script-audit` feature is enabled so the follow-up audit command can use the script level checks.

All tests pass.
