### PR TITLE
build(deps): bump vpin from 0.31.1 to 0.32.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,9 +2550,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d060dadf04acf32892b99d2b4913be9aa1a40eb9077026e8437d8de520ef7ac9"
+checksum = "95a9c966d646e9c0159ae3a204b4a591948ad1c374e30966687eb135b79f19d3"
 dependencies = [
  "bytes",
  "cfb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.31.1", features = ["script-audit"] }
+vpin = { version = "0.32.0", features = ["script-audit"] }
 directb2s = "0.1.1"
 
 edit = "0.1.5"


### PR DESCRIPTION
Bumps vpin from 0.31.1 to 0.32.0.

The release adds the semantic table diff and a batch of new audit checks. The breaking changes are limited to the audit finding variants, which nothing on main uses yet, so no code changes are needed. All tests pass.

Follow-ups once merged: rebase the audit PR #869 on it, then add a diff command on the new semantic diff API.