### PR TITLE
build(deps): bump vpin from 0.32.0 to 0.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,9 +2559,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a9c966d646e9c0159ae3a204b4a591948ad1c374e30966687eb135b79f19d3"
+checksum = "821a0d1ae27958f6c315ab1a909baa4267e666734b213676e539a093cd5ea5ee"
 dependencies = [
  "bytes",
  "cfb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.32.0", features = ["script-audit"] }
+vpin = { version = "0.32.1", features = ["script-audit"] }
 directb2s = "0.1.1"
 
 edit = "0.1.5"


### PR DESCRIPTION
Bumps vpin from 0.32.0 to 0.32.1.

The release leaves the editor layer visibility of items and drag points out of the semantic diff, since showing or hiding a layer is an editor view setting rather than a table change. No API changes, all tests pass.