### PR TITLE
feat(frontend): keep a play log with recently and most played lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ launch them.
 
 ![Frontend](docs/frontend.png)
 
+Every launch from the frontend is appended to a play log in the platform data directory
+(`~/.local/share/vpxtool/play_log.jsonl` on Linux). The "Recently played" and "Most played" entries
+in the main menu are built from it; runs shorter than 30 seconds are kept in the log but do not count
+as a play.
+
 ## Configuration
 
 A configuration file will be written to store among others the Visual Pinball executable location. The config file is

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -9,6 +9,7 @@ use crate::config::{LaunchTemplate, ResolvedConfig};
 use crate::indexer::{IndexError, IndexedTable, Progress};
 use crate::patcher::LineEndingsResult::{NoChanges, Unified};
 use crate::patcher::unify_line_endings_vbs_file;
+use crate::playlog::{self, PlayRecord, TableStats};
 use crate::vpinball_config::{VPinballConfig, WindowInfo, WindowType};
 use crate::{describe_exit, indexer, strip_cr_lf, was_killed_by_signal};
 use base64::Engine;
@@ -20,8 +21,10 @@ use indicatif::{ProgressBar, ProgressStyle};
 use is_executable::IsExecutable;
 use pinmame_nvram::dips::{DipSwitchState, get_all_dip_switches, set_dip_switches};
 use pinmame_nvram::{DipSwitchInfo, Nvram};
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::BufReader;
+use std::time::{Duration, Instant};
 use std::{
     fs::File,
     io,
@@ -35,9 +38,17 @@ const LAUNCH: Emoji = Emoji("🚀", "[launch]");
 const CRASH: Emoji = Emoji("💥", "[crash]");
 
 const SEARCH: &str = "> Search";
-const RECENT: &str = "> Recent";
+const RECENTLY_ADDED: &str = "> Recently added";
+const RECENTLY_PLAYED: &str = "> Recently played";
+const MOST_PLAYED: &str = "> Most played";
 const SEARCH_INDEX: usize = 0;
-const RECENT_INDEX: usize = 1;
+const RECENTLY_ADDED_INDEX: usize = 1;
+const RECENTLY_PLAYED_INDEX: usize = 2;
+const MOST_PLAYED_INDEX: usize = 3;
+/// Entries before the table list in the main menu
+const FIXED_ENTRIES: usize = 4;
+/// How many tables the recent and most played lists show
+const LIST_SIZE: usize = 50;
 
 #[derive(PartialEq, Eq, Clone)]
 enum TableOption {
@@ -168,7 +179,12 @@ pub fn frontend(
             .map(display_table_line_full)
             .collect();
 
-        let mut selections = vec![SEARCH.bold().to_string(), RECENT.bold().to_string()];
+        let mut selections = vec![
+            SEARCH.bold().to_string(),
+            RECENTLY_ADDED.bold().to_string(),
+            RECENTLY_PLAYED.bold().to_string(),
+            MOST_PLAYED.bold().to_string(),
+        ];
         selections.extend(tables.clone());
 
         if let Err(e) = Term::stderr().clear_screen() {
@@ -198,7 +214,7 @@ pub fn frontend(
 
                         if let Some(selected_index) = selected {
                             // return to the main list with the table selected
-                            main_selection_opt = Some(selected_index + 2);
+                            main_selection_opt = Some(selected_index + FIXED_ENTRIES);
                             let info = vpx_files_with_tableinfo
                                 .get(selected_index)
                                 .unwrap()
@@ -213,43 +229,93 @@ pub fn frontend(
                             );
                         }
                     }
-                    RECENT_INDEX => {
-                        // take the last 50 most recently modified tables
+                    RECENTLY_ADDED_INDEX => {
+                        // the most recently modified table files
                         let mut recent: Vec<IndexedTable> = vpx_files_with_tableinfo.clone();
-                        recent.sort_by_key(|indexed| indexed.last_modified);
-                        let last_modified = recent.iter().rev().take(50).collect::<Vec<_>>();
-                        let last_modified_str: Vec<String> = last_modified
-                            .iter()
-                            .map(|indexed| display_table_line_full(indexed))
+                        recent.sort_by_key(|indexed| std::cmp::Reverse(indexed.last_modified));
+                        recent.truncate(LIST_SIZE);
+                        let entries: Vec<(IndexedTable, String)> = recent
+                            .into_iter()
+                            .map(|indexed| {
+                                let line = display_table_line_full(&indexed);
+                                (indexed, line)
+                            })
                             .collect();
-
-                        let mut recent_selection: Option<usize> = None;
-                        loop {
-                            let selected = Select::with_theme(&ColorfulTheme::default())
-                                .with_prompt("Select a table")
-                                .items(&last_modified_str)
-                                .default(recent_selection.unwrap_or(0))
-                                .interact_opt()
-                                .unwrap();
-
-                            if let Some(selected_index) = selected {
-                                recent_selection = Some(selected_index);
-                                let info = last_modified.get(selected_index).unwrap();
-                                let info_str = display_table_line_full(info);
-                                table_menu(
-                                    config,
-                                    configured_pinmame_folder,
-                                    &mut vpx_files_with_tableinfo,
-                                    info,
-                                    &info_str,
+                        pick_from_list(
+                            config,
+                            configured_pinmame_folder,
+                            &mut vpx_files_with_tableinfo,
+                            &entries,
+                        );
+                    }
+                    RECENTLY_PLAYED_INDEX => {
+                        let stats = playlog::load_stats();
+                        let mut played = played_tables(&vpx_files_with_tableinfo, &stats);
+                        played.sort_by(|(_, a), (_, b)| b.last_played.cmp(&a.last_played));
+                        played.truncate(LIST_SIZE);
+                        let entries: Vec<(IndexedTable, String)> = played
+                            .into_iter()
+                            .map(|(indexed, stats)| {
+                                let line = format!(
+                                    "{} {}",
+                                    display_table_line_full(&indexed),
+                                    format!(
+                                        "(last {}, {} plays)",
+                                        stats.last_played_date().unwrap_or("?"),
+                                        stats.plays
+                                    )
+                                    .dimmed()
                                 );
-                            } else {
-                                break;
-                            }
+                                (indexed, line)
+                            })
+                            .collect();
+                        if entries.is_empty() {
+                            prompt("No plays recorded yet, launch a table from here first.");
+                        } else {
+                            pick_from_list(
+                                config,
+                                configured_pinmame_folder,
+                                &mut vpx_files_with_tableinfo,
+                                &entries,
+                            );
+                        }
+                    }
+                    MOST_PLAYED_INDEX => {
+                        let stats = playlog::load_stats();
+                        let mut played = played_tables(&vpx_files_with_tableinfo, &stats);
+                        played.sort_by(|(_, a), (_, b)| {
+                            (b.plays, b.total_seconds).cmp(&(a.plays, a.total_seconds))
+                        });
+                        played.truncate(LIST_SIZE);
+                        let entries: Vec<(IndexedTable, String)> = played
+                            .into_iter()
+                            .map(|(indexed, stats)| {
+                                let line = format!(
+                                    "{} {}",
+                                    display_table_line_full(&indexed),
+                                    format!(
+                                        "({} plays, {})",
+                                        stats.plays,
+                                        playlog::format_duration(stats.total_seconds)
+                                    )
+                                    .dimmed()
+                                );
+                                (indexed, line)
+                            })
+                            .collect();
+                        if entries.is_empty() {
+                            prompt("No plays recorded yet, launch a table from here first.");
+                        } else {
+                            pick_from_list(
+                                config,
+                                configured_pinmame_folder,
+                                &mut vpx_files_with_tableinfo,
+                                &entries,
+                            );
                         }
                     }
                     _ => {
-                        let index = selection - 2;
+                        let index = selection - FIXED_ENTRIES;
 
                         let info = vpx_files_with_tableinfo.get(index).unwrap().clone();
                         let info_str = display_table_line_full(&info);
@@ -265,6 +331,56 @@ pub fn frontend(
             }
             None => break,
         };
+    }
+}
+
+/// The indexed tables that have plays in the log, with their statistics
+fn played_tables(
+    tables: &[IndexedTable],
+    stats: &HashMap<PathBuf, TableStats>,
+) -> Vec<(IndexedTable, TableStats)> {
+    tables
+        .iter()
+        .filter_map(|indexed| {
+            stats
+                .get(&indexed.path)
+                .map(|table_stats| (indexed.clone(), table_stats.clone()))
+        })
+        .collect()
+}
+
+/// Shows a list of tables and opens the table menu for the chosen one,
+/// until the user backs out of the list
+fn pick_from_list(
+    config: &ResolvedConfig,
+    configured_pinmame_folder: Option<&Path>,
+    vpx_files_with_tableinfo: &mut Vec<IndexedTable>,
+    entries: &[(IndexedTable, String)],
+) {
+    let lines: Vec<&String> = entries.iter().map(|(_, line)| line).collect();
+    let mut selection: Option<usize> = None;
+    loop {
+        let selected = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Select a table")
+            .items(&lines)
+            .default(selection.unwrap_or(0))
+            .interact_opt()
+            .unwrap();
+
+        match selected {
+            Some(selected_index) => {
+                selection = Some(selected_index);
+                let (info, info_str) = &entries[selected_index];
+                table_menu(
+                    config,
+                    configured_pinmame_folder,
+                    vpx_files_with_tableinfo,
+                    info,
+                    info_str,
+                );
+            }
+            None => break,
+        }
     }
 }
 
@@ -919,7 +1035,13 @@ fn launch(selected_path: &PathBuf, launch_template: &LaunchTemplate) {
         ));
     }
 
-    match launch_table(selected_path, launch_template) {
+    let started = chrono::Utc::now();
+    let clock = Instant::now();
+    let result = launch_table(selected_path, launch_template);
+    if let Ok(status) = &result {
+        record_play(selected_path, started, clock.elapsed(), *status);
+    }
+    match result {
         Ok(status) if status.success() => {
             Term::stderr().clear_screen().ok();
         }
@@ -945,6 +1067,35 @@ fn launch(selected_path: &PathBuf, launch_template: &LaunchTemplate) {
                 report_and_exit(format!("Unable to launch table: {e:?}"));
             }
         }
+    }
+}
+
+/// Appends the run to the play log; a failure to write only warns, the
+/// launch itself already happened
+fn record_play(
+    selected_path: &Path,
+    started: chrono::DateTime<chrono::Utc>,
+    duration: Duration,
+    status: ExitStatus,
+) {
+    let Some(log_path) = playlog::play_log_path() else {
+        return;
+    };
+    let path = selected_path
+        .canonicalize()
+        .unwrap_or_else(|_| selected_path.to_path_buf());
+    let record = PlayRecord {
+        path,
+        started: started.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        seconds: duration.as_secs(),
+        exit: if status.success() {
+            "ok".to_string()
+        } else {
+            describe_exit(status)
+        },
+    };
+    if let Err(e) = playlog::append(&log_path, &record) {
+        eprintln!("Unable to write play log {}: {e}", log_path.display());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod capture;
 pub mod fixprint;
 mod frontend;
 pub mod patcher;
+pub mod playlog;
 
 pub mod config;
 

--- a/src/playlog.rs
+++ b/src/playlog.rs
@@ -1,0 +1,201 @@
+//! Launch history of the frontend: one JSON line per vpinball run.
+//!
+//! The log is append only and lives in the platform data directory
+//! (`~/.local/share/vpxtool/play_log.jsonl` on Linux). Reading folds it
+//! into per table statistics; runs shorter than [`MIN_PLAY_SECONDS`]
+//! stay in the log but do not count as a play, so a table that crashed
+//! on load does not show up as recently played.
+
+use log::warn;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+/// Runs shorter than this are a failed or aborted start, not a play
+pub const MIN_PLAY_SECONDS: u64 = 30;
+
+/// One vpinball run started from the frontend
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlayRecord {
+    /// Absolute path of the vpx file
+    pub path: PathBuf,
+    /// Start time as RFC 3339 in UTC, which sorts chronologically as text
+    pub started: String,
+    /// How long vpinball ran
+    pub seconds: u64,
+    /// "ok" for a clean exit, otherwise how vpinball ended
+    pub exit: String,
+}
+
+/// What the log knows about one table
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TableStats {
+    pub plays: u32,
+    /// Start time of the most recent play, RFC 3339 UTC
+    pub last_played: Option<String>,
+    pub total_seconds: u64,
+}
+
+impl TableStats {
+    /// The date part of the last play, for display
+    pub fn last_played_date(&self) -> Option<&str> {
+        self.last_played
+            .as_deref()
+            .map(|started| &started[..10.min(started.len())])
+    }
+}
+
+/// The play log location, `None` when the platform has no data directory
+pub fn play_log_path() -> Option<PathBuf> {
+    dirs::data_dir().map(|data_dir| data_dir.join("vpxtool").join("play_log.jsonl"))
+}
+
+/// Appends one record, creating the log and its directory when needed
+pub fn append(path: &Path, record: &PlayRecord) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let line = serde_json::to_string(record)?;
+    writeln!(file, "{line}")
+}
+
+/// Reads all records, skipping lines that do not parse. A missing log is empty.
+pub fn read(path: &Path) -> io::Result<Vec<PlayRecord>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let reader = BufReader::new(File::open(path)?);
+    let mut records = Vec::new();
+    for (index, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<PlayRecord>(&line) {
+            Ok(record) => records.push(record),
+            Err(e) => warn!("Skipping play log line {}: {e}", index + 1),
+        }
+    }
+    Ok(records)
+}
+
+/// Folds the records into per table statistics, counting only real plays
+pub fn fold(records: &[PlayRecord]) -> HashMap<PathBuf, TableStats> {
+    let mut stats: HashMap<PathBuf, TableStats> = HashMap::new();
+    for record in records {
+        if record.seconds < MIN_PLAY_SECONDS {
+            continue;
+        }
+        let entry = stats.entry(record.path.clone()).or_default();
+        entry.plays += 1;
+        entry.total_seconds += record.seconds;
+        if entry
+            .last_played
+            .as_ref()
+            .is_none_or(|last| record.started > *last)
+        {
+            entry.last_played = Some(record.started.clone());
+        }
+    }
+    stats
+}
+
+/// Reads and folds the log at the default location, empty when there is none
+pub fn load_stats() -> HashMap<PathBuf, TableStats> {
+    let Some(path) = play_log_path() else {
+        return HashMap::new();
+    };
+    match read(&path) {
+        Ok(records) => fold(&records),
+        Err(e) => {
+            warn!("Unable to read play log {}: {e}", path.display());
+            HashMap::new()
+        }
+    }
+}
+
+/// A short human duration: "45s", "12m", "2h 05m"
+pub fn format_duration(seconds: u64) -> String {
+    let minutes = seconds / 60;
+    let hours = minutes / 60;
+    if hours > 0 {
+        format!("{hours}h {:02}m", minutes % 60)
+    } else if minutes > 0 {
+        format!("{minutes}m")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn record(path: &str, started: &str, seconds: u64) -> PlayRecord {
+        PlayRecord {
+            path: PathBuf::from(path),
+            started: started.to_string(),
+            seconds,
+            exit: "ok".to_string(),
+        }
+    }
+
+    #[test]
+    fn append_and_read_round_trip() -> io::Result<()> {
+        let dir = testdir::testdir!();
+        let path = dir.join("nested").join("play_log.jsonl");
+        let first = record("/tables/a.vpx", "2026-09-10T20:00:00Z", 120);
+        let second = record("/tables/b.vpx", "2026-09-10T21:00:00Z", 5);
+        append(&path, &first)?;
+        append(&path, &second)?;
+
+        assert_eq!(read(&path)?, vec![first, second]);
+        Ok(())
+    }
+
+    #[test]
+    fn read_skips_bad_lines_and_missing_log() -> io::Result<()> {
+        let dir = testdir::testdir!();
+        let path = dir.join("play_log.jsonl");
+        assert_eq!(read(&path)?, Vec::new());
+
+        let good = record("/tables/a.vpx", "2026-09-10T20:00:00Z", 120);
+        std::fs::write(
+            &path,
+            format!("not json\n{}\n\n", serde_json::to_string(&good)?),
+        )?;
+        assert_eq!(read(&path)?, vec![good]);
+        Ok(())
+    }
+
+    #[test]
+    fn fold_counts_plays_above_the_threshold() {
+        let records = vec![
+            record("/tables/a.vpx", "2026-09-01T10:00:00Z", 600),
+            record("/tables/a.vpx", "2026-09-03T10:00:00Z", 10),
+            record("/tables/a.vpx", "2026-09-02T10:00:00Z", 300),
+            record("/tables/b.vpx", "2026-09-05T10:00:00Z", 29),
+        ];
+        let stats = fold(&records);
+        assert_eq!(
+            stats.get(Path::new("/tables/a.vpx")),
+            Some(&TableStats {
+                plays: 2,
+                last_played: Some("2026-09-02T10:00:00Z".to_string()),
+                total_seconds: 900,
+            })
+        );
+        assert_eq!(stats.get(Path::new("/tables/b.vpx")), None);
+    }
+
+    #[test]
+    fn duration_formatting() {
+        assert_eq!(format_duration(45), "45s");
+        assert_eq!(format_duration(12 * 60 + 30), "12m");
+        assert_eq!(format_duration(2 * 3600 + 5 * 60), "2h 05m");
+    }
+}


### PR DESCRIPTION
Every launch from the frontend now appends a line to a play log: the table path, start time, how long vpinball ran and how it exited. The log is append only JSON lines in the platform data directory (`~/.local/share/vpxtool/play_log.jsonl` on Linux, the dirs crate equivalents elsewhere).

The main menu gains two entries built from it. "Recently played" lists tables by last play, "Most played" by play count and time played, each with the numbers next to the table name. The existing "Recent" entry, which sorts by file modification date, is renamed "Recently added". Runs shorter than 30 seconds stay in the log but do not count as a play, so a table that crashed on load does not show up as recently played.

Closes #141. First slice of #449: the same log can later back play statistics, a trimmer for old entries, and a score-server listener for per game data.