### PR TITLE
feat: extract only part of a table with --only and --no-media

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,24 @@ Options:
   -h, --help       Print help
 ```
 
+### Extracting part of a table
+
+`extract` writes the whole table as a directory of JSON, script, image, sound and mesh files. To get only some
+of them, filter on the paths that `ls` prints, relative to the output directory. A `*` does not cross a
+directory separator, so `gameitems/*.json` is the game item files and `*.json` the top level index files.
+
+```shell
+# only the game data
+vpxtool extract --only gamedata.json table.vpx
+# the script and every game item, but no meshes
+vpxtool extract --only script.vbs --only 'gameitems/*.json' table.vpx
+# everything except the image and sound files; their index files are still written
+vpxtool extract --no-media table.vpx
+```
+
+Files that are filtered out are not produced at all, so extracting only the JSON of a large table takes
+milliseconds. A partial directory cannot be assembled back into a table.
+
 ### Logging
 
 To get more information about what vpxtool is doing, you can set the `-v` flag to increase verbosity.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ use colored::Colorize;
 use console::Emoji;
 use directb2s::read;
 use git_version::git_version;
+use globset::{GlobBuilder, GlobSetBuilder};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{LevelFilter, info};
 use pinmame_nvram::dips::get_all_dip_switches;
@@ -463,6 +464,14 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 .get_one::<String>("VPXPATH")
                 .map(|s| s.as_str())
                 .unwrap_or_default();
+            let filter = ExtractFilter {
+                only: sub_matches
+                    .get_many::<String>("ONLY")
+                    .unwrap_or_default()
+                    .cloned()
+                    .collect(),
+                no_media: sub_matches.get_flag("NO_MEDIA"),
+            };
             let expanded_path = path_exists(path)?;
             let ext = expanded_path.extension().map(|e| e.to_ascii_lowercase());
             match ext {
@@ -473,7 +482,12 @@ fn handle_command(matches: ArgMatches) -> io::Result<ExitCode> {
                 }
                 Some(ext) if ext == "vpx" => {
                     crate::println!("extracting from {}", expanded_path.display())?;
-                    extract(expanded_path.as_ref(), force, output_dir.as_deref())
+                    extract(
+                        expanded_path.as_ref(),
+                        force,
+                        output_dir.as_deref(),
+                        &filter,
+                    )
                 }
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -1301,6 +1315,19 @@ fn build_command() -> Command {
                         .long("output-dir")
                         .num_args(1)
                         .help("Directory to extract into. Defaults to a folder named after the vpx, next to it."),
+                )
+                .arg(
+                    Arg::new("ONLY")
+                        .long("only")
+                        .value_name("GLOB")
+                        .action(ArgAction::Append)
+                        .help("Only write the files matching this glob, on the path relative to the output directory as `ls` prints it, for example gamedata.json or 'gameitems/*.json'. A * does not cross a directory separator. Repeatable"),
+                )
+                .arg(
+                    Arg::new("NO_MEDIA")
+                        .long("no-media")
+                        .action(ArgAction::SetTrue)
+                        .help("Skip the image and sound files, their index files are still written"),
                 )
                 .arg(arg!(<VPXPATH> "The path to the vpx file").required(true)),
         )
@@ -3097,7 +3124,54 @@ pub fn confirm(msg: String, yes_no_question: String) -> io::Result<bool> {
     Ok(input.trim() == "y")
 }
 
-pub fn extract(vpx_file_path: &Path, yes: bool, output_dir: Option<&Path>) -> io::Result<ExitCode> {
+/// Which files `extract` writes; everything when nothing is set
+#[derive(Debug, Default, Clone)]
+pub struct ExtractFilter {
+    /// Globs on the path relative to the output directory, as `ls` prints it
+    pub only: Vec<String>,
+    /// Skip the image and sound files, keeping their index files
+    pub no_media: bool,
+}
+
+impl ExtractFilter {
+    /// The expand options, carrying a path filter when anything is set
+    fn expand_options(&self) -> io::Result<ExpandOptions> {
+        if self.only.is_empty() && !self.no_media {
+            return Ok(ExpandOptions::default());
+        }
+        let mut builder = GlobSetBuilder::new();
+        for pattern in &self.only {
+            let glob = GlobBuilder::new(pattern)
+                .literal_separator(true)
+                .build()
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("invalid --only glob '{pattern}': {e}"),
+                    )
+                })?;
+            builder.add(glob);
+        }
+        let only = builder
+            .build()
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        let has_only = !self.only.is_empty();
+        let no_media = self.no_media;
+        Ok(ExpandOptions::default().filter(move |path: &Path| {
+            let media = path.starts_with("images") || path.starts_with("sounds");
+            (!has_only || only.is_match(path)) && !(no_media && media)
+        }))
+    }
+}
+
+pub fn extract(
+    vpx_file_path: &Path,
+    yes: bool,
+    output_dir: Option<&Path>,
+    filter: &ExtractFilter,
+) -> io::Result<ExitCode> {
+    // a bad glob should fail before anything is touched
+    let options = filter.expand_options()?;
     let default_dir = vpx_file_path.with_extension("");
     let root_dir_path = output_dir.unwrap_or(default_dir.as_path());
 
@@ -3120,7 +3194,6 @@ pub fn extract(vpx_file_path: &Path, yes: bool, output_dir: Option<&Path>) -> io
     root_dir.create(root_dir_path)?;
     let result = {
         let vpx = vpx::read(vpx_file_path)?;
-        let options = ExpandOptions::default();
         expanded::write(&vpx, &root_dir_path, &options)
     };
     match result {

--- a/tests/extract_filter.rs
+++ b/tests/extract_filter.rs
@@ -1,0 +1,111 @@
+//! `extract --only` and `--no-media` write part of a table.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use testdir::testdir;
+
+fn vpxtool(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_vpxtool"))
+        .args(args)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn vpxtool")
+        .wait_with_output()
+        .expect("failed to wait for vpxtool")
+}
+
+/// All files below `dir`, relative, sorted, with `/` separators
+fn files(dir: &Path) -> Vec<String> {
+    fn walk(root: &Path, dir: &Path, out: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).expect("read dir").flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(root, &path, out);
+            } else {
+                let relative = path.strip_prefix(root).expect("below root");
+                out.push(relative.to_string_lossy().replace('\\', "/"));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(dir, dir, &mut out);
+    out.sort();
+    out
+}
+
+fn fixture(dir: &Path) -> String {
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata")
+        .join("completely_blank_table_10_7_4.vpx");
+    std::fs::copy(source, dir.join("table.vpx")).expect("copy fixture");
+    "table.vpx".to_string()
+}
+
+#[test]
+fn only_keeps_the_named_file() {
+    let dir = testdir!();
+    let table = fixture(&dir);
+    let out = vpxtool(
+        &dir,
+        &["extract", "--only", "gamedata.json", "-o", "out", &table],
+    );
+    assert!(out.status.success(), "extract failed: {:?}", out);
+    assert_eq!(files(&dir.join("out")), vec!["gamedata.json"]);
+}
+
+#[test]
+fn only_glob_does_not_cross_directories() {
+    let dir = testdir!();
+    let table = fixture(&dir);
+    let out = vpxtool(
+        &dir,
+        &["extract", "--only", "gameitems/*.json", "-o", "out", &table],
+    );
+    assert!(out.status.success(), "extract failed: {:?}", out);
+    let written = files(&dir.join("out"));
+    assert!(!written.is_empty());
+    assert!(
+        written
+            .iter()
+            .all(|f| f.starts_with("gameitems/") && f.ends_with(".json"))
+    );
+    assert!(!written.contains(&"gameitems.json".to_string()));
+}
+
+#[test]
+fn no_media_skips_the_image_files_but_keeps_the_index() {
+    let dir = testdir!();
+    let table = fixture(&dir);
+    let out = vpxtool(&dir, &["extract", "--no-media", "-o", "out", &table]);
+    assert!(out.status.success(), "extract failed: {:?}", out);
+    let written = files(&dir.join("out"));
+    assert!(written.contains(&"images.json".to_string()));
+    assert!(written.contains(&"gamedata.json".to_string()));
+    assert!(
+        written
+            .iter()
+            .all(|f| !f.starts_with("images/") && !f.starts_with("sounds/"))
+    );
+    assert!(!dir.join("out").join("images").exists());
+}
+
+#[test]
+fn bad_glob_fails_before_writing() {
+    let dir = testdir!();
+    let table = fixture(&dir);
+    let out = vpxtool(
+        &dir,
+        &["extract", "--only", "gameitems/[", "-o", "out", &table],
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        (stderr.to_string() + &stdout).contains("invalid --only glob"),
+        "unexpected output: {stdout} {stderr}"
+    );
+    assert!(!dir.join("out").exists());
+}


### PR DESCRIPTION
Adds two options to `extract` for getting part of a table without paying for all of it.

`--only <glob>` writes only the files whose path, relative to the output directory and as `ls` prints it, matches the glob. It can be repeated. A `*` does not cross a directory separator, so `gameitems/*.json` is the game item files and `*.json` the top level index files. `--no-media` skips the image and sound files while their index files are still written, so the directory documents what was left out. Filtered out files are never produced: on a 628 MB table, `--only gamedata.json` writes 8 KB in milliseconds where a full extract writes 1.2 GB.

Builds on `ExpandOptions::filter` from vpin 0.33.0.

Closes #305