### PR TITLE
build(deps): bump vpin from 0.32.1 to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,9 +2559,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821a0d1ae27958f6c315ab1a909baa4267e666734b213676e539a093cd5ea5ee"
+checksum = "75d1c887d247f2b4392014737aa4f968fb1d2e46c11a531a1abc863b38579427"
 dependencies = [
  "bytes",
  "cfb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.32.1", features = ["script-audit"] }
+vpin = { version = "0.33.0", features = ["script-audit"] }
 directb2s = "0.1.1"
 
 edit = "0.1.5"


### PR DESCRIPTION
Bumps vpin from 0.32.1 to 0.33.0.

The release adds the expanded write filter that the draft PR #878 builds on, more audit checks (duplicate data under different names, materials sharing a name, script keyword names, lights whose fade speed cannot move, items without a name), and several read fixes for tables saved by old vpinball builds. No code changes were needed here; all tests pass.

Timing on a 628 MB table, release build: `extract` unchanged at about 2.4 s, `audit` from 0.54 s to 0.71 s because the new duplicate data check hashes every image and sound payload.