### PR TITLE
build(deps): bump vpin from 0.33.0 to 0.33.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,9 +2559,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vpin"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d1c887d247f2b4392014737aa4f968fb1d2e46c11a531a1abc863b38579427"
+checksum = "114de74df67d6608375da931b21bfa258eff33e2f8e6e76427870d4ccfee75de"
 dependencies = [
  "bytes",
  "cfb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wild = "2.2.1"
 
 is_executable = "1.0.5"
 regex = { version = "1.12.3", features = [] }
-vpin = { version = "0.33.0", features = ["script-audit"] }
+vpin = { version = "0.33.1", features = ["script-audit"] }
 directb2s = "0.1.1"
 
 edit = "0.1.5"


### PR DESCRIPTION
Bumps vpin from 0.33.0 to 0.33.1, which fixes the audit slowdown from the same data check (vpin #463).

`audit` timing, release build, one run after a warm-up:

| table | 0.32.1 | 0.33.0 | 0.33.1 |
|---|---|---|---|
| 103 MB, 914 expanded files | 0.08 s | 0.12 s | 0.08 s |
| 628 MB, 1634 expanded files | 0.54 s | 0.71 s | 0.59 s |

No code changes; all tests pass.